### PR TITLE
Fixing a bug in the RoleMixin eq/ne functions

### DIFF
--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -164,12 +164,12 @@ class RoleMixin(object):
     def __eq__(self, other):
         if isinstance(other, basestring):
             return self.name == other
-        return self.name == other.name
+        return self.name == getattr(other, 'name', None)
 
     def __ne__(self, other):
         if isinstance(other, basestring):
             return self.name != other
-        return self.name != other.name
+        return self.name != getattr(other, 'name', None)
 
     def __str__(self):
         return '<Role name=%s, description=%s>' % (self.name, self.description)


### PR DESCRIPTION
Changed other.name to getattr(other, 'name', None) to fix a bug where
other is not a Role object.
