### PR TITLE
correct roles_* decorator signature expectations

### DIFF
--- a/example/app.py
+++ b/example/app.py
@@ -28,6 +28,7 @@ def create_roles():
 def create_users():
     for u in  (('matt@lp.com', 'password', ['admin'], True),
                ('joe@lp.com', 'password', ['editor'], True),
+               ('dave@lp.com', 'password', ['admin', 'editor'], True),
                ('jill@lp.com', 'password', ['author'], True),
                ('tiya@lp.com', 'password', [], False)):
         current_app.security.datastore.create_user(
@@ -95,6 +96,11 @@ def create_app(auth_config):
     @roles_required('admin')
     def admin():
         return render_template('index.html', content='Admin Page')
+
+    @app.route('/admin_and_editor')
+    @roles_required('admin', 'editor')
+    def admin_and_editor():
+        return render_template('index.html', content='Admin and Editor Page')
 
     @app.route('/admin_or_editor')
     @roles_accepted('admin', 'editor')

--- a/tests/functional_tests.py
+++ b/tests/functional_tests.py
@@ -84,6 +84,16 @@ class DefaultSecurityTests(SecurityTest):
         r = self._get('/admin', follow_redirects=True)
         self.assertIn('<input id="next"', r.data)
 
+    def test_multiple_role_required(self):
+        for user in ("matt@lp.com", "joe@lp.com"):
+            self.authenticate(user)
+            r = self._get("/admin_and_editor", follow_redirects=True)
+            self.assertIsHomePage(r.data)
+
+        self.authenticate('dave@lp.com')
+        r = self._get("/admin_and_editor")
+        self.assertIn('Admin and Editor Page', r.data)
+
     def test_token_auth_via_querystring_valid_token(self):
         r = self._get('/token?auth_token=123abc')
         self.assertIn('Token Authentication', r.data)


### PR DESCRIPTION
Having multiple RoleNeed objects in a Permission does not require
all to be satisfied in order to .can(), but will return True if
any are present.  This makes the previous roles_required logic more
elegant for roles_accepted.  roles_required decorator needs to check
all permissions individually and return only if all permissions exist
