### PR TITLE
small bug in the example app

### DIFF
--- a/example/app.py
+++ b/example/app.py
@@ -14,8 +14,8 @@ from flask.ext.mongoengine import MongoEngine
 from flask.ext.sqlalchemy import SQLAlchemy
 from flask.ext.security import Security, LoginForm, login_required, \
      roles_required, roles_accepted, UserMixin, RoleMixin
-from flask.ext.security.datastore import SQLAlchemyUserDatastore, \
-     MongoEngineUserDatastore
+from flask.ext.security.datastore.sqlalchemy import SQLAlchemyUserDatastore
+from flask.ext.security.datastore.mongoengine import MongoEngineUserDatastore
 from flask.ext.security.decorators import http_auth_required, \
      auth_token_required
 


### PR DESCRIPTION
See Stackoverflow question http://stackoverflow.com/questions/11912788/importerror-no-module-named-flask-ext-security-datastore-sqlalchemyuserdatastor, looks like the example app was calling an older API?
