### PR TITLE
Pass 'next' url to form context during login

### DIFF
--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -76,7 +76,8 @@ def login():
         if not request.json:
             return redirect(get_post_login_redirect())
 
-    form.next.data = request.args.get('next') or request.form.get('next') or ''
+    form.next.data = get_url(request.args.get('next')) \
+                     or get_url(request.form.get('next')) or ''
 
     if request.json:
         return _render_json(form, True)


### PR DESCRIPTION
In the `'login_user.html'` template, the following field is always rendered as empty, because it's never provided from the context:

```
{{ render_field(login_user_form.next) }}
```

Then it's posted back to the login url as such. This pull request attempts to address this issue, and restore the 'next' url functionality when a user logs in with it present as a GET or POST variable. 

This is also a problem during registration, but it's much more involved, since there currently isn't a 'next' attribute on the register forms. I'm not sure if that's by design or not. I haven't wrapped my head around the confirmed registration code yet, but it seems there should be an option to dynamically direct a user after registration.
