### PR TITLE
Fix query for find_user

### DIFF
--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -57,7 +57,7 @@ class UserDatastore(object):
 
     def _prepare_role_modify_args(self, user, role):
         if isinstance(user, basestring):
-            user = self.find_user(email=user.email)
+            user = self.find_user(email=user)
         if isinstance(role, basestring):
             role = self.find_role(role)
         return user, role


### PR DESCRIPTION
Fix for https://github.com/mattupstate/flask-security/issues/55. 

Fixes the kwargs being passed to `find_user`.
