### PR TITLE
Make default sql datastore setting in test_app configurable.

### DIFF
--- a/tests/test_app/sqlalchemy.py
+++ b/tests/test_app/sqlalchemy.py
@@ -17,8 +17,7 @@ from tests.test_app import create_app as create_base_app, populate_data, \
 def create_app(config, **kwargs):
     app = create_base_app(config)
 
-    #app.config['SQLALCHEMY_DATABASE_URI'] = 'mysql://root@localhost/flask_security_test'
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv('DATABASE_URL', 'mysql://root@localhost/flask_security_test')
 
     db = SQLAlchemy(app)
 


### PR DESCRIPTION
Reverts the test_app sql datastore to mysql, but uses DATABASE_URL
from env to override. Let's people easily test with;
  DATABASE_URL=sqlite:// nosetests
instead of setting up a local mysql.
