### PR TITLE
Fix passing category to login required message

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -157,10 +157,8 @@ def _get_login_manager(app):
     lm.login_view = '%s.login' % cv('BLUEPRINT_NAME', app=app)
     lm.user_loader(_user_loader)
     lm.token_loader(_token_loader)
-    lm.login_message = cv('MSG_LOGIN', app=app)
-    lm.login_message_category = 'info'
-    lm.needs_refresh_message = cv('MSG_REFRESH', app=app)
-    lm.needs_refresh_message_category = 'info'
+    lm.login_message, lm.login_message_category = cv('MSG_LOGIN', app=app)
+    lm.needs_refresh_message, lm.needs_refresh_message_category = cv('MSG_REFRESH', app=app)
     lm.init_app(app)
     return lm
 

--- a/tests/functional_tests.py
+++ b/tests/functional_tests.py
@@ -60,7 +60,7 @@ class DefaultSecurityTests(SecurityTest):
 
     def test_unauthorized_access(self):
         r = self._get('/profile', follow_redirects=True)
-        self.assertIn('Please log in to access this page', r.data)
+        self.assertIn('<li class="message">Please log in to access this page.</li>', r.data)
 
     def test_authorized_access(self):
         self.authenticate()


### PR DESCRIPTION
The previous code would make the message appear as 

```
('Please log in to access this page.', 'info')
```

Now it's

```
Please log in to access this page.
```

and the category is passed from the list in core.py.
