### PR TITLE
Password should be encoded as 'utf-8' before creating hmac to support passwords with non-latin symbols

### DIFF
--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -78,7 +78,7 @@ def get_hmac(password):
             'must not be None when the value of `SECURITY_PASSWORD_HASH` is '
             'set to "%s"' % _security.password_hash)
 
-    h = hmac.new(_security.password_salt, password, hashlib.sha512)
+    h = hmac.new(_security.password_salt, password.encode('utf-8'), hashlib.sha512)
     return base64.b64encode(h.digest())
 
 


### PR DESCRIPTION
I received UnicodeEncodeError: 'ascii' codec can't encode character u'\u0439' in position 0: ordinal not in range(128) when I tried to use password with non-latin (russian) symbols.
