### PR TITLE
Make subdomain configurable

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -33,6 +33,7 @@ _security = LocalProxy(lambda: current_app.extensions['security'])
 _default_config = {
     'BLUEPRINT_NAME': 'security',
     'URL_PREFIX': None,
+    'SUBDOMAIN': None,
     'FLASH_MESSAGES': True,
     'PASSWORD_HASH': 'plaintext',
     'PASSWORD_SALT': None,

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -283,6 +283,7 @@ def create_blueprint(state, import_name):
 
     bp = Blueprint(state.blueprint_name, import_name,
                    url_prefix=state.url_prefix,
+                   subdomain=state.subdomain,
                    template_folder='templates')
 
     bp.route(state.logout_url, endpoint='logout')(logout)


### PR DESCRIPTION
This give the ability to set the subdomain for flask-security views.
