### PR TITLE
Fixed http_auth when authorization is not provided in header

### DIFF
--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -67,7 +67,9 @@ def _check_token():
 
 
 def _check_http_auth():
-    auth = request.authorization or dict(username=None, password=None)
+    from collections import namedtuple
+    Auth = namedtuple('Auth', 'username, password')
+    auth = request.authorization or Auth(username=None, password=None)
     user = _security.datastore.find_user(email=auth.username)
 
     if user and utils.verify_and_update_password(auth.password, user):

--- a/tests/functional_tests.py
+++ b/tests/functional_tests.py
@@ -142,6 +142,13 @@ class DefaultSecurityTests(SecurityTest):
         })
         self.assertIn('HTTP Authentication', r.data)
 
+    def test_http_auth_no_authorization(self):
+        r = self._get('/http', headers={})
+        self.assertIn('<h1>Unauthorized</h1>', r.data)
+        self.assertIn('WWW-Authenticate', r.headers)
+        self.assertEquals('Basic realm="Login Required"',
+                          r.headers['WWW-Authenticate'])
+
     def test_invalid_http_auth_invalid_username(self):
         r = self._get('/http', headers={
             'Authorization': 'Basic ' + base64.b64encode("bogus:bogus")


### PR DESCRIPTION
If no authorization was present in the header, the _check_http function was trying to access the username and password attributes on a dict (AttributeError exception was raised). 
Changed the dict to be a named tuple.
