### PR TITLE
Changed has_role to accept strings with mongoengine. Fixes #110

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -241,8 +241,7 @@ class RoleMixin(object):
                 self.name == getattr(other, 'name', None))
 
     def __ne__(self, other):
-        return (self.name != other and
-                self.name != getattr(other, 'name', None))
+        return not self.__eq__(other)
 
 
 class UserMixin(BaseUserMixin):
@@ -261,7 +260,10 @@ class UserMixin(BaseUserMixin):
         """Returns `True` if the user identifies with the specified role.
 
         :param role: A role name or `Role` instance"""
-        return role in self.roles
+        if isinstance(role, basestring):
+            return role in (role.name for role in self.roles)
+        else:
+            return role in self.roles
 
 
 class AnonymousUser(AnonymousUserBase):


### PR DESCRIPTION
This is the cleanest way I could come up with to fix issue #110. Basically, when a string is passed to `has_role`, I'm dereferencing each role name from the list of role objects to a string generator.

I feel putting `RoleMixin` before `db.Document` in the inheritance chain, as Matt suggested in the issue, isn't exactly the most transparent way to resolve this. 

The only other way I could think of would be to use `Permission(RoleNeed(role)).can()` in the case of a string, but I believe that would mess with the context. It definitely causes the current `has_role` tests to fail.

Also, I slipped in a small DRY change for the `RoleMixin` class.
