### PR TITLE
Make flask-login respect SECURITY_FLASH_MESSAGES

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -179,8 +179,14 @@ def _get_login_manager(app):
     lm.login_view = '%s.login' % cv('BLUEPRINT_NAME', app=app)
     lm.user_loader(_user_loader)
     lm.token_loader(_token_loader)
-    lm.login_message, lm.login_message_category = cv('MSG_LOGIN', app=app)
-    lm.needs_refresh_message, lm.needs_refresh_message_category = cv('MSG_REFRESH', app=app)
+
+    if cv('FLASH_MESSAGES', app=app):
+        lm.login_message, lm.login_message_category = cv('MSG_LOGIN', app=app)
+        lm.needs_refresh_message, lm.needs_refresh_message_category = cv('MSG_REFRESH', app=app)
+    else:
+        lm.login_message = None
+        lm.needs_refresh_message = None
+
     lm.init_app(app)
     return lm
 


### PR DESCRIPTION
Since `flask-security` relies upon `flask-login` for the `@login_required` decorator, the latter module does not look for the `SECURITY_FLASH_MESSAGES` flag.

This pull request fixes that, passing `None` as the flashed message if that flag is set to `False`.
