### PR TITLE
Update recoverable.py

### DIFF
--- a/flask_security/recoverable.py
+++ b/flask_security/recoverable.py
@@ -29,8 +29,7 @@ def send_reset_password_instructions(user):
     :param user: The user to send the instructions to
     """
     token = generate_reset_password_token(user)
-    url = url_for_security('reset_password', token=token)
-    reset_link = request.url_root[:-1] + url
+    reset_link = url_for_security('reset_password', token=token, _external=True)
 
     send_mail(config_value('EMAIL_SUBJECT_PASSWORD_RESET'), user.email,
               'reset_instructions',


### PR DESCRIPTION
Fixed invalid url when app used on subpath, e.g. 'http://localhost/api'. There are links with doubled 'api': "http://localhost/api/api/reset_password/TOKEN"
