### PR TITLE
Email confirmation fix

### DIFF
--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -203,6 +203,8 @@ def send_confirmation():
 def confirm_email(token):
     """View function which handles a email confirmation request."""
 
+    logout_user()
+
     expired, invalid, user = confirm_email_token_status(token)
 
     if not user or invalid:


### PR DESCRIPTION
Email confirmation can be a useful feature, but requiring email confirmation in order to log in can diminish the quality of the user experience (http://www.quora.com/Is-requiring-email-confirmation-bad-for-user-experience). That is why I opted to work with the following settings:

SECURITY_CONFIRMABLE = True
SECURITY_LOGIN_WITHOUT_CONFIRMATION = True

However, with these settings, email confirmation doesn't actually work. Here's why:
1. User registers
2. User is logged in
3. User receives a confirmation email
4. User clicks the confirmation email link
5. /confirm/ has "@anonymous_user_required" enabled and so doesn't actually lead to user confirmation (you can verify this by looking in your db under the "confirmed_at" field)
   TL;DR: email confirmation only works if the user logs out after registering and before clicking the link (clearly a problem)

There are two lines of code that have been added to fix this:
1. Removed "@anonymous_user_required" as a decorator of "confirm_email(token)"
2. Added "logout_user()" as the first line of "confirm_email(token)"

Note that this change is compatible with the following settings as well:

SECURITY_CONFIRMABLE = True
SECURITY_LOGIN_WITHOUT_CONFIRMATION = False

That is because even if a different user is currently logged in, that user will be logged out and then the user tied to the confirmation link will have their email confirmed and will be logged in.*

*Real world example: Let's say Jason logs in and then logs out and doesn't click the confirmation link. Then, Sarah, using the same computer, logs in and doesn't log out. Then, Jason returns to the computer and clicks the confirmation link. Now you're trying to do confirm_user() and login_user() on Jason when Sarah is already logged in. It is better to make sure that no other user is currently logged in.
