### PR TITLE
Ignore validation errors in find_user

### DIFF
--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -194,10 +194,14 @@ class MongoEngineUserDatastore(MongoEngineDatastore, UserDatastore):
             from mongoengine.queryset import Q, QCombination
         except ImportError:
             from mongoengine.queryset.visitor import Q, QCombination
+        from mongoengine.errors import ValidationError
 
         queries = map(lambda i: Q(**{i[0]: i[1]}), kwargs.items())
         query = QCombination(QCombination.AND, queries)
-        return self.user_model.objects(query).first()
+        try:
+            return self.user_model.objects(query).first()
+        except ValidationError:
+            return None
 
     def find_role(self, role):
         return self.role_model.objects(name=role).first()


### PR DESCRIPTION
I hit an interesting corner-case while developing two Flask projects that use Flask-Security. In one project, I'm using Postgresql and in the second, MongoEngine. The session contains a `user_id` of the last logged-in user and every time I switch from the Postgres project to MongoEngine, I see a `ValidationError` when viewing any page until I manually clear the session.

The error was vague, showing me just that `u'1'` was not the expected `ObjectId` type. After some digging, I noticed that ID originated from the session. This change allows you to skip the manual process of deleting the session cookie, assuming you've seen this before and know that's what you need to do.

Semantically, Flask-Login shouldn't fail when looking for a user that comes from the session, since there's no such user of an invalid user string. I initially thought I'd address this there, or in core.py's `_user_loader` function, but then that code needs to know which database or `Datastore` you're using.
