### PR TITLE
Update forms.py

### DIFF
--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -10,7 +10,10 @@
 """
 
 import inspect
-import urlparse
+ try:
+     import urllib.parse as urlparse
+ except ImportError:
+     import urlparse
 
 import flask_wtf as wtf
 


### PR DESCRIPTION
The urlparse module is renamed to urllib.parse in Python 3. The 2to3 tool will automatically adapt imports when converting your sources to Python 3.
http://docs.python.org/2/library/urlparse.html
