### PR TITLE
Use get_json instead of json

### DIFF
--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -51,7 +51,7 @@ def _check_token():
     args_key = _security.token_authentication_key
     header_token = request.headers.get(header_key, None)
     token = request.args.get(args_key, header_token)
-    if request.json:
+    if request.get_json(silent=True):
         token = request.json.get(args_key, token)
 
     user = _security.login_manager.token_callback(token)


### PR DESCRIPTION
The `request.json` method now calls `get_json`, which raises `BadRequest` if there is no json data or some error with it. So, it cannot be directly used as a check for presence of json data. This code currently returns a bad request if content type is `application/json` but json data is empty.

https://github.com/mitsuhiko/flask/blob/master/flask/wrappers.py#L110
