### PR TITLE
Allows field labels to be set in config

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -126,6 +126,22 @@ _default_messages = {
     'REFRESH': ('Please reauthenticate to access this page.', 'info'),
 }
 
+_default_field_labels = {
+    'EMAIL': 'Email Address',
+    'PASSWORD': 'Password',
+    'REMEMBER_ME': 'Remember Me',
+    'LOGIN': 'Login',
+    'RETYPE_PASSWORD': 'Retype Password',
+    'REGISTER': 'Register',
+    'SEND_CONFIRMATION': 'Resend Confirmation Instructions',
+    'RECOVER_PASSWORD': 'Recover Password',
+    'RESET_PASSWORD': 'Reset Password',
+    'RETYPE_PASSWORD': 'Retype Password',
+    'NEW_PASSWORD': 'New Password',
+    'CHANGE_PASSWORD': 'Change Password',
+    'SEND_LOGIN_LINK': 'Send Login Link'
+}
+
 _allowed_password_hash_schemes = [
     'bcrypt',
     'des_crypt',
@@ -371,6 +387,9 @@ class Security(object):
 
         for key, value in _default_messages.items():
             app.config.setdefault('SECURITY_MSG_' + key, value)
+
+        for key, value in _default_field_labels.items():
+            app.config.setdefault('SECURITY_LABEL_' + key, value)
 
         identity_loaded.connect_via(app)(_on_identity_loaded)
 

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -23,26 +23,10 @@ from flask_login import current_user
 from werkzeug.local import LocalProxy
 
 from .confirmable import requires_confirmation
-from .utils import verify_and_update_password, get_message, config_value
+from .utils import verify_and_update_password, get_message, config_value, get_label
 
 # Convenient reference
 _datastore = LocalProxy(lambda: current_app.extensions['security'].datastore)
-
-_default_field_labels = {
-    'email': 'Email Address',
-    'password': 'Password',
-    'remember_me': 'Remember Me',
-    'login': 'Login',
-    'retype_password': 'Retype Password',
-    'register': 'Register',
-    'send_confirmation': 'Resend Confirmation Instructions',
-    'recover_password': 'Recover Password',
-    'reset_password': 'Reset Password',
-    'retype_password': 'Retype Password',
-    'new_password': 'New Password',
-    'change_password': 'Change Password',
-    'send_login_link': 'Send Login Link'
-}
 
 
 class ValidatorMixin(object):
@@ -74,8 +58,19 @@ password_required = Required(message='PASSWORD_NOT_PROVIDED')
 password_length = Length(min=6, max=128, message='PASSWORD_INVALID_LENGTH')
 
 
+class LabelProxy(unicode):
+    def __init__(self, key):
+        self._key = key
+
+    def __str__(self):
+        return get_label(self._key)
+
+    def __unicode__(self):
+        return get_label(self._key)
+
+
 def get_form_field_label(key):
-    return _default_field_labels.get(key, '')
+    return LabelProxy(key)
 
 
 def unique_user_email(form, field):

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -232,6 +232,11 @@ def get_message(key, **kwargs):
     return rv[0] % kwargs, rv[1]
 
 
+def get_label(key, **kwargs):
+    rv = config_value('LABEL_' + key, default="")
+    return rv % kwargs
+
+
 def config_value(key, app=None, default=None):
     """Get a Flask-Security configuration value.
 


### PR DESCRIPTION
This makes it relatively easy to e.g. localise them, by simply in your app config saying

```python
from flask.ext.babel import lazy_gettext as _

SECURITY_LABEL_EMAIL = _("Email Address")
SECURITY_LABEL_PASSWORD = _("Password")
```

I guess the problem with #155 was that the forms classes were constructed outside an application context. I solved that by creating a proxy object that holds back the actual string realisation until it's needed.

This makes #18 also relatively trivial now.