### PR TITLE
Make logout view do nothing if the user is already logged out

### DIFF
--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -88,11 +88,11 @@ def login():
                                      **_ctx('login'))
 
 
-@login_required
 def logout():
     """View function which handles a logout request."""
 
-    logout_user()
+    if current_user.is_authenticated():
+        logout_user()
 
     return redirect(request.args.get('next', None) or
                     get_url(_security.post_logout_view))


### PR DESCRIPTION
Currently if the user visits `/logout` while not being logged in, they will be redirected to `/login` and after successful authentication immediately logged out again. That doesn't make a lot of sense and can be pretty confusing. Apparently this can even happen if the user is logged in: as soon as you type `/logout` into address bar in Chrome it does a "prerender" request and when you press enter it may request `/logout` again (no idea why).

I made `logout` view simply redirect to `SECURITY_POST_LOGOUT_VIEW` if the user is already logged out.
