### PR TITLE
verify_password in 1.7.0 was no longer behaving like in 1.6.9

### DIFF
--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -111,7 +111,10 @@ def verify_password(password, password_hash):
     :param password: A plaintext password to verify
     :param password_hash: The expected hash value of the password (usually form your database)
     """
-    return _pwd_context.verify(encrypt_password(password), password_hash)
+    if _security.password_hash != 'plaintext':
+        password = get_hmac(password)
+
+    return _pwd_context.verify(password, password_hash)
 
 
 def verify_and_update_password(password, user):

--- a/tests/configured_tests.py
+++ b/tests/configured_tests.py
@@ -20,6 +20,19 @@ from flask_security.signals import user_registered
 from tests import SecurityTest
 
 
+class PasswordVerifyEncryptTests(SecurityTest):
+
+    AUTH_CONFIG = {
+        'SECURITY_PASSWORD_HASH': 'bcrypt',
+        'SECURITY_PASSWORD_SALT': '89gf828uiguiu23ju2'
+    }
+
+    def test_verify_password_bcrypt(self):
+        from flask_security.utils import verify_password, encrypt_password
+        with self.app.app_context():
+            self.assertTrue(verify_password('custompassword', encrypt_password('custompassword')))
+
+
 class ConfiguredPasswordHashSecurityTests(SecurityTest):
 
     AUTH_CONFIG = {


### PR DESCRIPTION
Maybe related to https://github.com/mattupstate/flask-security/issues/210

Simple experimental code with bcrypt no longer returned true:
`verify_password('psw', encrypt_password('psw'))`

Not sure if my fix is correct but at least the created tests started to pass and it's similar to how the latest verify_and_update_password works.

This pull request is against "develop", let me know if this is wrong and should be against some other branch.
