### PR TITLE
Remove active duplicate with database default

### DIFF
--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -75,7 +75,6 @@ class UserDatastore(object):
         return user, role
 
     def _prepare_create_user_args(self, **kwargs):
-        kwargs.setdefault('active', True)
         roles = kwargs.get('roles', [])
         for i, role in enumerate(roles):
             rn = role.name if isinstance(role, self.role_model) else role


### PR DESCRIPTION
This duplicates with the default value in the database and doesn't allow creation of inactive users without a lot of code.

Use case: inactive user self-registration with manual activation by an administrator
