### PR TITLE
Proposing change to rending json responses

### DIFF
--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -42,7 +42,7 @@ def _render_json(form, include_auth_token=False, include_id=True):
         response = dict(errors=form.errors)
     else:
         code = 200
-	resonse = dict()
+    resonse = dict()
         if include_id:
             response['user'] = dict(id=str(form.user.id)))
         if include_auth_token:


### PR DESCRIPTION
While investigating how to use flask-security via AJAX, I noticed that a JSON request for forgot_password will send me an email as a result, while sending back a response like this:

{
  "meta": {
    "code": 200
  },
  "response": {
    "user": {
      "id": "12"
    }
  }
}

I would suggest that this is a security issue: I can send over an arbitrary email in the request, and tell not only if the email is in the database, but also get its primary key ID. This change adds a parameter to the render_json function which controls whether or not to send over the user_id. The default is set to True, so the rest of the code should just work. Maybe this should be a configurable option? If not, calls to this function should set this parameter to False where appropriate.
