### PR TITLE
Allow overriding of an unauthorized callback.

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -273,7 +273,8 @@ def _get_state(app, datastore, **kwargs):
         reset_serializer=_get_serializer(app, 'reset'),
         confirm_serializer=_get_serializer(app, 'confirm'),
         _context_processors={},
-        _send_mail_task=None
+        _send_mail_task=None,
+        _unauthorized_callback=None
     ))
 
     for key, value in _default_forms.items():
@@ -380,6 +381,9 @@ class _SecurityState(object):
 
     def send_mail_task(self, fn):
         self._send_mail_task = fn
+
+    def unauthorized_handler(self, fn):
+        self._unauthorized_callback = fn
 
 
 class Security(object):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -192,3 +192,19 @@ def test_password_unicode_password_salt(client):
     assert response.status_code == 302
     response = authenticate(client, follow_redirects=True)
     assert b'Hello matt@lp.com' in response.data
+
+
+def test_set_unauthorized_handler(app, client):
+    @app.security.unauthorized_handler
+    def unauthorized():
+        app.unauthorized_handler_set = True
+        return 'unauthorized-handler-set', 401
+
+    app.unauthorized_handler_set = False
+
+    authenticate(client, "joe@lp.com")
+    response = client.get("/admin", follow_redirects=True)
+
+    assert app.unauthorized_handler_set is True
+    assert b'unauthorized-handler-set' in response.data
+    assert response.status_code == 401


### PR DESCRIPTION
Right now, when using `@http_auth_required` or `@auth_token_required`, if the user is unauthorized only a message is returned (`_default_unauthorized_html`).

With this change, it is possible to define an unauthorized callback which will be called instead.

Example using your overholt project (`overholt/api/__init__.py`):

```python
from overholt.core import security

def unauthorized():
    return jsonify(dict(error='Unauthorized')), 403

def create_app(settings_override=None, register_security_blueprint=False):
    app = factory.create_app(__name__, __path__, settings_override,
                             register_security_blueprint=register_security_blueprint)
    security.unauthorized_handler(unauthorized)

```

I have tested it only with `@http_auth_required`, but `@auth_required` and `@auth_token_required` should work pretty much the same.