### PR TITLE
expose flask-login token-loader to use a custom token_loader

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -376,6 +376,15 @@ class _SecurityState(object):
     def send_mail_task(self, fn):
         self._send_mail_task = fn
 
+    def token_loader(self, callback):
+        """set the callback for flask-login token_loader
+        Args:
+            callback : the function which will return the User
+        Return:
+            the callback itself (same behaviour as flask-login)
+        """
+        return self.login_manager.token_loader(callback)
+
 
 class Security(object):
     """The :class:`Security` class initializes the Flask-Security extension.


### PR DESCRIPTION
I need to create a custom token (also to avoid using md5 hash) and want to use all the goodies flask-security brings (it's tied with a web application which uses flask-security)
it's just a matter of exposing the token_loader decorator of flask_login.

an example is the following:

```
security = Security(Flask(__name__))

@security.token_loader
def api_token_loader(token):
    try:
        if token is not None:
            user = user_datastore.find_user(user_key=token)
            if user is not None:
                return user
    except:
        pass
    return AnonymousUser()
```

and the user token can be generated any way we desire (i.e. resorting to our favourite RNG and hashing algo)
