### PR TITLE
Custom request loader

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -226,7 +226,7 @@ def _request_loader(request):
         if user is not None:
             return user
     except Exception as e:
-        print e
+        pass
     # finally, return AnonymousUser instance if both methods
     # did not login the user
     return None

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -376,6 +376,15 @@ class _SecurityState(object):
     def send_mail_task(self, fn):
         self._send_mail_task = fn
 
+    def token_loader(self, callback):
+        """set the callback for flask-login token_loader
+        Args:
+            callback : the function which will return the User
+        Return:
+            the callback itself (same behaviour as flask-login)
+        """
+        return self.login_manager.token_loader(callback)
+
 
 class Security(object):
     """The :class:`Security` class initializes the Flask-Security extension.

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -225,7 +225,7 @@ def _request_loader(request):
 
         if user is not None:
             return user
-    except Exception as e:
+    except Exception:
         pass
     # finally, return AnonymousUser instance if both methods
     # did not login the user

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -19,11 +19,14 @@ from passlib.context import CryptContext
 from werkzeug.datastructures import ImmutableList
 from werkzeug.local import LocalProxy
 
-from .utils import config_value as cv, get_config, md5, url_for_security, string_types
+from .utils import config_value as cv, get_config, md5,\
+    url_for_security, string_types
 from .views import create_blueprint
 from .forms import LoginForm, ConfirmRegisterForm, RegisterForm, \
     ForgotPasswordForm, ChangePasswordForm, ResetPasswordForm, \
     SendConfirmationForm, PasswordlessLoginForm
+
+import base64
 
 # Convenient references
 _security = LocalProxy(lambda: current_app.extensions['security'])
@@ -106,7 +109,8 @@ _default_messages = {
     'UNAUTHORIZED': (
         'You do not have permission to view this resource.', 'error'),
     'CONFIRM_REGISTRATION': (
-        'Thank you. Confirmation instructions have been sent to %(email)s.', 'success'),
+        'Thank you. Confirmation instructions have been sent to %(email)s.',
+        'success'),
     'EMAIL_CONFIRMED': (
         'Thank you. Your email has been confirmed.', 'success'),
     'ALREADY_CONFIRMED': (
@@ -122,10 +126,11 @@ _default_messages = {
     'INVALID_REDIRECT': (
         'Redirections outside the domain are forbidden', 'error'),
     'PASSWORD_RESET_REQUEST': (
-        'Instructions to reset your password have been sent to %(email)s.', 'info'),
+        'Instructions to reset your password have been sent to %(email)s.',
+        'info'),
     'PASSWORD_RESET_EXPIRED': (
-        'You did not reset your password within %(within)s. New instructions have been sent '
-        'to %(email)s.', 'error'),
+        'You did not reset your password within %(within)s. New instructions '
+        'have been sent to %(email)s.', 'error'),
     'INVALID_RESET_PASSWORD_TOKEN': (
         'Invalid reset password token.', 'error'),
     'CONFIRMATION_REQUIRED': (
@@ -133,11 +138,11 @@ _default_messages = {
     'CONFIRMATION_REQUEST': (
         'Confirmation instructions have been sent to %(email)s.', 'info'),
     'CONFIRMATION_EXPIRED': (
-        'You did not confirm your email within %(within)s. New instructions to confirm your email '
-        'have been sent to %(email)s.', 'error'),
+        'You did not confirm your email within %(within)s. New instructions to'
+        'confirm your email have been sent to %(email)s.', 'error'),
     'LOGIN_EXPIRED': (
-        'You did not login within %(within)s. New instructions to login have been sent to '
-        '%(email)s.', 'error'),
+        'You did not login within %(within)s. New instructions to login '
+        'have been sent to %(email)s.', 'error'),
     'LOGIN_EMAIL_SENT': (
         'Instructions to login have been sent to %(email)s.', 'success'),
     'INVALID_LOGIN_TOKEN': (
@@ -161,10 +166,12 @@ _default_messages = {
     'PASSWORDLESS_LOGIN_SUCCESSFUL': (
         'You have successfuly logged in.', 'success'),
     'PASSWORD_RESET': (
-        'You successfully reset your password and you have been logged in automatically.',
+        'You successfully reset your password and you have been '
+        'logged in automatically.',
         'success'),
     'PASSWORD_IS_THE_SAME': (
-        'Your new password must be different than your previous password.', 'error'),
+        'Your new password must be different than your previous password.',
+        'error'),
     'PASSWORD_CHANGE': (
         'You successfully changed your password.', 'success'),
     'LOGIN': (
@@ -200,6 +207,31 @@ def _token_loader(token):
     return AnonymousUser()
 
 
+def _request_loader(request):
+    # first, try to login using the api_key url arg
+    api_key = request.form['api_key']
+
+    if not api_key:
+    # no, try to login using Basic Auth
+        api_key = request.headers.get('Authorization')
+        if api_key:
+            api_key = api_key.replace('Basic ', '', 1)
+            try:
+                api_key = base64.b64decode(api_key)
+            except TypeError:
+                return None
+    try:
+        user = _security.datastore.find_user(API_key=api_key)
+
+        if user is not None:
+            return user
+    except Exception as e:
+        print e
+    # finally, return AnonymousUser instance if both methods
+    # did not login the user
+    return None
+
+
 def _identity_loader():
     if not isinstance(current_user._get_current_object(), AnonymousUser):
         identity = Identity(current_user.id)
@@ -222,10 +254,12 @@ def _get_login_manager(app):
     lm.login_view = '%s.login' % cv('BLUEPRINT_NAME', app=app)
     lm.user_loader(_user_loader)
     lm.token_loader(_token_loader)
+    lm.request_loader(_request_loader)
 
     if cv('FLASH_MESSAGES', app=app):
         lm.login_message, lm.login_message_category = cv('MSG_LOGIN', app=app)
-        lm.needs_refresh_message, lm.needs_refresh_message_category = cv('MSG_REFRESH', app=app)
+        lm.needs_refresh_message, lm.needs_refresh_message_category = cv(
+            'MSG_REFRESH', app=app)
     else:
         lm.login_message = None
         lm.needs_refresh_message = None
@@ -246,7 +280,8 @@ def _get_pwd_context(app):
     deprecated = cv('DEPRECATED_PASSWORD_SCHEMES', app=app)
     if pw_hash not in schemes:
         allowed = (', '.join(schemes[:-1]) + ' and ' + schemes[-1])
-        raise ValueError("Invalid hash scheme %r. Allowed values are %s" % (pw_hash, allowed))
+        raise ValueError(
+            "Invalid hash scheme %r. Allowed values are %s" % (pw_hash, allowed))
     return CryptContext(schemes=schemes, default=pw_hash, deprecated=deprecated)
 
 
@@ -286,6 +321,7 @@ def _context_processor():
 
 
 class RoleMixin(object):
+
     """Mixin for `Role` model definitions"""
 
     def __eq__(self, other):
@@ -300,6 +336,7 @@ class RoleMixin(object):
 
 
 class UserMixin(BaseUserMixin):
+
     """Mixin for `User` model definitions"""
 
     def is_active(self):
@@ -322,6 +359,7 @@ class UserMixin(BaseUserMixin):
 
 
 class AnonymousUser(AnonymousUserMixin):
+
     """AnonymousUser definition"""
 
     def __init__(self):
@@ -376,22 +414,15 @@ class _SecurityState(object):
     def send_mail_task(self, fn):
         self._send_mail_task = fn
 
-    def token_loader(self, callback):
-        """set the callback for flask-login token_loader
-        Args:
-            callback : the function which will return the User
-        Return:
-            the callback itself (same behaviour as flask-login)
-        """
-        return self.login_manager.token_loader(callback)
-
 
 class Security(object):
+
     """The :class:`Security` class initializes the Flask-Security extension.
 
     :param app: The application.
     :param datastore: An instance of a user datastore.
     """
+
     def __init__(self, app=None, datastore=None, **kwargs):
         self.app = app
         self.datastore = datastore

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -209,18 +209,19 @@ def _token_loader(token):
 
 def _request_loader(request):
     # first, try to login using the api_key url arg
-    api_key = request.form['api_key']
-
-    if not api_key:
-    # no, try to login using Basic Auth
-        api_key = request.headers.get('Authorization')
-        if api_key:
-            api_key = api_key.replace('Basic ', '', 1)
-            try:
-                api_key = base64.b64decode(api_key)
-            except TypeError:
-                return None
     try:
+        api_key = request.form['api_key']
+
+        if not api_key:
+            # no, try to login using Basic Auth
+            api_key = request.headers.get('Authorization')
+            if api_key:
+                api_key = api_key.replace('Basic ', '', 1)
+                try:
+                    api_key = base64.b64decode(api_key)
+                except TypeError:
+                    return None
+
         user = _security.datastore.find_user(API_key=api_key)
 
         if user is not None:

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -47,8 +47,6 @@ def _get_unauthorized_response(text=None, headers=None, json_response=False):
         text = text or _default_unauthorized_html
     else:
         text = text or _default_unauthorized_json
-        print "ASDFALRGFAERIOGJAEROGJO"
-        print text
         response = jsonify(status=text)
         response.status_code = 401
         return response

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -12,9 +12,11 @@
 from collections import namedtuple
 from functools import wraps
 
-from flask import current_app, Response, request, redirect, _request_ctx_stack
+from flask import current_app, Response, request, redirect,\
+    _request_ctx_stack, jsonify
 from flask.ext.login import current_user, login_required  # pragma: no flakes
-from flask.ext.principal import RoleNeed, Permission, Identity, identity_changed
+from flask.ext.principal import RoleNeed, Permission,\
+    Identity, identity_changed
 from werkzeug.local import LocalProxy
 
 from . import utils
@@ -26,17 +28,31 @@ _security = LocalProxy(lambda: current_app.extensions['security'])
 
 _default_unauthorized_html = """
     <h1>Unauthorized</h1>
-    <p>The server could not verify that you are authorized to access the URL
+    <p>
+    The server could not verify that you are authorized to access the URL
     requested. You either supplied the wrong credentials (e.g. a bad password),
-    or your browser doesn't understand how to supply the credentials required.</p>
+    or your browser doesn't understand how to supply the credentials required.
+    </p>
     """
+
+_default_unauthorized_json = 'unauthorized'
 
 BasicAuth = namedtuple('BasicAuth', 'username, password')
 
 
-def _get_unauthorized_response(text=None, headers=None):
-    text = text or _default_unauthorized_html
+def _get_unauthorized_response(text=None, headers=None, json_response=False):
     headers = headers or {}
+
+    if not json_response:
+        text = text or _default_unauthorized_html
+    else:
+        text = text or _default_unauthorized_json
+        print "ASDFALRGFAERIOGJAEROGJO"
+        print text
+        response = jsonify(status=text)
+        response.status_code = 401
+        return response
+
     return Response(text, 401, headers)
 
 
@@ -116,6 +132,20 @@ def auth_token_required(fn):
     return decorated
 
 
+def auth_request_required(json_response=False):
+    def auth_request_required_decorator(fn):
+        """Decorator that protects endpoints using a request authentication
+        """
+
+        @wraps(fn)
+        def decorated(*args, **kwargs):
+            if current_user.is_authenticated():
+                return fn(*args, **kwargs)
+            return _get_unauthorized_response(json_response=json_response)
+        return decorated
+    return auth_request_required_decorator
+
+
 def auth_required(*auth_methods):
     """
     Decorator that protects enpoints through multiple mechanisms
@@ -137,7 +167,8 @@ def auth_required(*auth_methods):
     def wrapper(fn):
         @wraps(fn)
         def decorated_view(*args, **kwargs):
-            mechanisms = [login_mechanisms.get(method) for method in auth_methods]
+            mechanisms = [
+                login_mechanisms.get(method) for method in auth_methods]
             for mechanism in mechanisms:
                 if mechanism and mechanism():
                     return fn(*args, **kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, pypy
+envlist = py27
 
 [testenv]
 deps =


### PR DESCRIPTION
Flask-login allows authenticating every request through a request loader (i.e. rest API auth)
and added the request loader, the api key generation is for now left to the user (i implemented it as hash of the concatenation of user email and concatenation of random/secret data) and it could be added to the UserMixin class.

there's also this p.r. for flask-login https://github.com/maxcountryman/flask-login/pull/163 to avoid having unneeded cookies, at the moment is a global config, but it could be hacked to ensure that if it's a request for the request loader session can be cleaned, but would require more effort.