### PR TITLE
Fix verify_password to check passwords more consistantly

### DIFF
--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -115,9 +115,9 @@ def verify_password(password, password_hash):
     """Returns ``True`` if the password matches the supplied hash.
 
     :param password: A plaintext password to verify
-    :param password_hash: The expected hash value of the password (usually form your database)
+    :param password_hash: The expected hash value of the password (usually from your database)
     """
-    if _security.password_hash != 'plaintext':
+    if _pwd_context.identify(password_hash) != 'plaintext':
         password = get_hmac(password)
 
     return _pwd_context.verify(password, password_hash)


### PR DESCRIPTION
When verifying a password, the incoming password should be salted whenever
the stored password is not 'plaintext'. The decision to salt when
verifying existing passwords should not depend on the current value of
SECURITY_PASSWORD_HASH, as that may have changed since the password was
stored.

Commit 510d1356a2c2884c5895c321d1c8a65e1269b117 already fixed this issue
for verify_and_update_password. This makes verify_password work in the
same way.

Also fix a minor spelling error in documentation.
