### PR TITLE
strange recursion error, when using Security() and later init_app()

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -392,7 +392,7 @@ class Security(object):
         self.datastore = datastore
 
         if app is not None and datastore is not None:
-            self._state = self.init_app(app, datastore, **kwargs)
+            self.init_app(app, datastore, **kwargs)
 
     def init_app(self, app, datastore=None, register_blueprint=True,
                  login_form=None, confirm_register_form=None,
@@ -432,8 +432,8 @@ class Security(object):
 
         state.render_template = self.render_template
         app.extensions['security'] = state
-
-        return state
+        
+        self._state = state
 
     def render_template(self, *args, **kwargs):
         return render_template(*args, **kwargs)

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -432,7 +432,7 @@ class Security(object):
 
         state.render_template = self.render_template
         app.extensions['security'] = state
-        
+
         self._state = state
 
     def render_template(self, *args, **kwargs):


### PR DESCRIPTION
One can't do something like:

`my_security = Security()`
and later on
`my_security.init_app(app, ...)`

'cause that ends in a strange recursion. 
(Haven't tested that, but it should work. This was an issue on #pocoo from ianseyer)
