### PR TITLE
Committing changes in SQLAlchemyDatastore

### DIFF
--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -32,10 +32,12 @@ class SQLAlchemyDatastore(Datastore):
 
     def put(self, model):
         self.db.session.add(model)
+        self.commit()
         return model
 
     def delete(self, model):
         self.db.session.delete(model)
+        self.commit()
 
 
 class MongoEngineDatastore(Datastore):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,7 +179,7 @@ def sqlalchemy_datastore(request, app, tmpdir):
         login_count = db.Column(db.Integer)
         active = db.Column(db.Boolean())
         confirmed_at = db.Column(db.DateTime())
-        roles = db.relationship('Role', secondary=roles_users,
+        roles = db.relationship(Role, secondary=roles_users,
                                 backref=db.backref('users', lazy='dynamic'))
 
     with app.app_context():


### PR DESCRIPTION
When performing any action which modifies the data base like create_role or add_role_to_user, for example. The modifications wasn't committed into the database, so adding `self.commit()` in `SQLAlchemyDatastore` under the `put` and `delete` functions solves the issue.