### PR TITLE
Fix script. Add commands and a Sub-Manager

### DIFF
--- a/flask_security/script.py
+++ b/flask_security/script.py
@@ -131,7 +131,7 @@ class AddRoleCommand(_RoleCommand):
 
 
 class RemoveRoleCommand(_RoleCommand):
-    """Add a role to a user"""
+    """Remove a role from a user"""
 
     @commit
     def run(self, user_identifier, role_name):


### PR DESCRIPTION
I noticed script.py, not sure if this is deprecated or still in use...

Having the sub-manager will allow to do something like this in your main manage.py:

from flask.ext.security.script import manager as security_manager
manager.add_command('security', security_manager)

