### PR TITLE
Fail silently for get_user(None)

### DIFF
--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -195,7 +195,7 @@ class SQLAlchemyUserDatastore(SQLAlchemyDatastore, UserDatastore):
     def _is_numeric(self, value):
         try:
             int(value)
-        except ValueError:
+        except (TypeError, ValueError):
             return False
         return True
 


### PR DESCRIPTION
get_user(identifier) checks if the identifier is a number by trying to convert it to int. This works for strings, but in a particular case, when identifier is None, it fails. Checking for both TypeError and ValueError fixes it.