### PR TITLE
Fix #353, if user use an old access token, then the user will be None

### DIFF
--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -55,6 +55,8 @@ def _check_token():
         token = request.json.get(args_key, token)
 
     user = _security.login_manager.token_callback(token)
+    if user == None:
+        return False
 
     if user and user.is_authenticated():
         app = current_app._get_current_object()


### PR DESCRIPTION
if user use an old access token, then the user will be None, so we have to return False if the user is None