### PR TITLE
Added optional max_age parameter to token_callback

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -190,9 +190,9 @@ def _user_loader(user_id):
     return _security.datastore.find_user(id=user_id)
 
 
-def _token_loader(token):
+def _token_loader(token, max_age=None):
     try:
-        data = _security.remember_token_serializer.loads(token)
+        data = _security.remember_token_serializer.loads(token, max_age=max_age)
         user = _security.datastore.find_user(id=data[0])
         if user and safe_str_cmp(md5(user.password), data[1]):
             return user


### PR DESCRIPTION
This PR suggests an alternate to pull request #322 and provides the implementer with optional access to the expiration feature in Flask-Security's 'remember' serializer.  This is particularly helpful for those implementing a RESTful web service, as suggested by @waltaskew, where you might implement custom authorization checks that reject stale API tokens.

Because Flask-Security assigns a token callback function based on a URLSafeTimedSerializer, we can safely pass a max_age parameter to the callback
to check for token expiration. By adding this optional parameter to the
callback implemented by Flask-Security, projects are able to check for
token expiration using:

    user = current_app.login_manager.token_callback(token, max_age)

By default, this customization is not needed and out-of-the-box functionality is unaffected.