### PR TITLE
Include WWW-Authenticate headers in @auth_required.

### DIFF
--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -137,11 +137,15 @@ def auth_required(*auth_methods):
     def wrapper(fn):
         @wraps(fn)
         def decorated_view(*args, **kwargs):
-            mechanisms = [login_mechanisms.get(method) for method in auth_methods]
-            for mechanism in mechanisms:
+            h = {}
+            mechanisms = [(method, login_mechanisms.get(method)) for method in auth_methods]
+            for method, mechanism in mechanisms:
                 if mechanism and mechanism():
                     return fn(*args, **kwargs)
-            return _get_unauthorized_response()
+                elif method == 'basic':
+                    r = _security.default_http_auth_realm
+                    h['WWW-Authenticate'] = 'Basic realm="%s"' % r
+            return _get_unauthorized_response(headers=h)
         return decorated_view
     return wrapper
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -226,6 +226,19 @@ def test_multi_auth_basic(client):
     assert response.status_code == 401
 
 
+def test_multi_auth_basic_invalid(client):
+    response = client.get('/multi_auth', headers={
+        'Authorization': 'Basic %s' % base64.b64encode(b"bogus:bogus").decode('utf-8')
+    })
+    assert b'<h1>Unauthorized</h1>' in response.data
+    assert 'WWW-Authenticate' in response.headers
+    assert 'Basic realm="Login Required"' == response.headers['WWW-Authenticate']
+
+    response = client.get('/multi_auth')
+    print(response.headers)
+    assert response.status_code == 401
+
+
 def test_multi_auth_token(client):
     response = json_authenticate(client)
     token = response.jdata['response']['user']['authentication_token']


### PR DESCRIPTION
When using @http_auth_required, the WWW-Authenticate header is included, but when using @auth_required('basic'), it is not.

This change includes that header in every @auth_required call that contains the 'basic' method.