### PR TITLE
Encrypt raw password, not HMAC of password.

### DIFF
--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -10,8 +10,6 @@
     :license: MIT, see LICENSE for more details.
 """
 
-__version__ = '1.7.4'
-
 from .core import Security, RoleMixin, UserMixin, AnonymousUser, current_user
 from .datastore import SQLAlchemyUserDatastore, MongoEngineUserDatastore, PeeweeUserDatastore
 from .decorators import auth_token_required, http_auth_required, \
@@ -21,3 +19,5 @@ from .forms import ForgotPasswordForm, LoginForm, RegisterForm, \
 from .signals import confirm_instructions_sent, password_reset, \
     reset_password_instructions_sent, user_confirmed, user_registered
 from .utils import login_user, logout_user, url_for_security
+
+__version__ = '1.7.4'

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -8,7 +8,8 @@
 
 from pytest import raises
 
-from flask_security.utils import verify_password, verify_and_update_password, encrypt_password, get_hmac
+from flask_security.utils import verify_password, verify_and_update_password, encrypt_password, \
+        get_hmac
 
 from utils import authenticate, init_app_with_options
 

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -8,7 +8,7 @@
 
 from pytest import raises
 
-from flask_security.utils import verify_password, encrypt_password
+from flask_security.utils import verify_password, verify_and_update_password, encrypt_password, get_hmac
 
 from utils import authenticate, init_app_with_options
 
@@ -31,8 +31,28 @@ def test_login_with_bcrypt_enabled(app, sqlalchemy_datastore):
     assert b'Home Page' in response.data
 
 
-def test_missing_hash_salt_option(app, sqlalchemy_datastore):
-    with raises(RuntimeError):
-        init_app_with_options(app, sqlalchemy_datastore, **{
-            'SECURITY_PASSWORD_HASH': 'bcrypt',
-        })
+def test_passlib_compatibility(app, sqlalchemy_datastore):
+    init_app_with_options(app, sqlalchemy_datastore, **{
+        'SECURITY_PASSWORD_HASH': 'bcrypt',
+        'SECURITY_PASSWORD_SALT': 'salty'
+    })
+    with app.app_context():
+        # encrypt solely with passlib
+        enc = app.extensions['security'].pwd_context.encrypt('pass')
+        assert verify_password('pass', enc)
+
+        user = app.security.datastore.create_user(password=enc)
+        assert verify_and_update_password('pass', user)
+        assert user.password == enc
+
+        # passlib should be able to verify our encryption
+        enc = encrypt_password('pass')
+        assert app.extensions['security'].pwd_context.verify('pass', enc)
+
+        # ensure we can verify legacy HMAC encryption
+        enc = encrypt_password(get_hmac('pass'))
+        assert verify_password('pass', enc)
+
+        user = app.security.datastore.create_user(password=enc)
+        assert verify_and_update_password('pass', user)
+        assert user.password != enc


### PR DESCRIPTION
This passes passwords directly to passlib's CryptContext
methods and relies on it to do the hard work.

For backwards compatibility we fall back to trying the old HMAC approach
when verifying passwords, but only if a salt has been set. Legacy passwords
are updated upon check.

Previously, we passed the HMAC'd password to passlib, which meant that
we weren't compatible with other users of passlib (such as Django) or
the Modular Crypt Format at
https://pythonhosted.org/passlib/modular_crypt_format.html

Fixes #320
