### PR TITLE
Restrict bcrypt to <2.0.0

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -23,7 +23,10 @@ Core
                                          passwords. Recommended values for
                                          production systems are ``bcrypt``,
                                          ``sha512_crypt``, or ``pbkdf2_sha512``.
-                                         Defaults to ``plaintext``.
+                                         Defaults to ``plaintext``. Note:
+                                         ``bcrypt>=2.0.0`` is not currently
+                                         supported. If ``bcrypt`` is preferred,
+                                         please use ``bcrypt<2.0``.
 ``SECURITY_PASSWORD_SALT``               Specifies the HMAC salt. This is only
                                          used if the password hash type is set
                                          to something other than plain text.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 Flask-SQLAlchemy>=1.0
-bcrypt>=1.0.2
+bcrypt>=1.0.2,<2.0.0
 flask-mongoengine>=0.7.0
 flask-peewee>=0.6.5
 pymongo==2.8


### PR DESCRIPTION
As of 2.0.0, passlib no longer correctly identifies bcrypt as bcrypt
(instead, it mistakenly applies pybcrypt logic to bcrypt). This results
in all Python 3 logic involving bcrypt failing. As a hotfix, we should
require users to be on a version of bcrypt that passlib can handle a fix
can be pushed into passlib.