### PR TITLE
Test and fix script commands

### DIFF
--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -133,6 +133,7 @@ class UserDatastore(object):
         user = self._prepare_active_modify_args(user)
 
         user.active = not user.active
+        self.put(user)
         return True
 
     def deactivate_user(self, user):
@@ -144,6 +145,7 @@ class UserDatastore(object):
 
         if user.active:
             user.active = False
+            self.put(user)
             return True
         return False
 
@@ -156,6 +158,7 @@ class UserDatastore(object):
 
         if not user.active:
             user.active = True
+            self.put(user)
             return True
         return False
 

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -84,6 +84,11 @@ class UserDatastore(object):
         kwargs['roles'] = roles
         return kwargs
 
+    def _prepare_active_modify_args(self, user):
+        if isinstance(user, string_types):
+            user = self.find_user(email=user)
+        return user
+
     def get_user(self, id_or_email):
         """Returns a user matching the specified ID or email address."""
         raise NotImplementedError
@@ -125,6 +130,8 @@ class UserDatastore(object):
 
     def toggle_active(self, user):
         """Toggles a user's active status. Always returns True."""
+        user = self._prepare_active_modify_args(user)
+
         user.active = not user.active
         return True
 
@@ -133,6 +140,8 @@ class UserDatastore(object):
 
         :param user: The user to deactivate
         """
+        user = self._prepare_active_modify_args(user)
+
         if user.active:
             user.active = False
             return True
@@ -143,6 +152,8 @@ class UserDatastore(object):
 
         :param user: The user to activate
         """
+        user = self._prepare_active_modify_args(user)
+
         if not user.active:
             user.active = True
             return True

--- a/flask_security/script.py
+++ b/flask_security/script.py
@@ -40,7 +40,7 @@ class CreateUserCommand(Command):
     """Create a user"""
 
     option_list = (
-        Option('-e', '--email', dest='email', default=None),
+        Option('-e', '--email', dest='email', default=None, required=True),
         Option('-p', '--password', dest='password', default=None),
         Option('-a', '--active', dest='active', action='store_true'),
     )
@@ -67,7 +67,7 @@ class CreateRoleCommand(Command):
     """Create a role"""
 
     option_list = (
-        Option('-n', '--name', dest='name', default=None),
+        Option('-n', '--name', dest='name', default=None, required=True),
         Option('-d', '--desc', dest='description', default=None),
     )
 
@@ -79,8 +79,8 @@ class CreateRoleCommand(Command):
 
 class _RoleCommand(Command):
     option_list = (
-        Option('-u', '--user', dest='user_identifier'),
-        Option('-r', '--role', dest='role_name'),
+        Option('-u', '--user', dest='user_identifier', required=True),
+        Option('-r', '--role', dest='role_name', required=True),
     )
 
 
@@ -104,7 +104,7 @@ class RemoveRoleCommand(_RoleCommand):
 
 class _ToggleActiveCommand(Command):
     option_list = (
-        Option('-u', '--user', dest='user_identifier'),
+        Option('-u', '--user', dest='user_identifier', required=True),
     )
 
 

--- a/flask_security/script.py
+++ b/flask_security/script.py
@@ -61,6 +61,7 @@ class CreateUserCommand(Command):
         else:
             print('Error creating user')
             pprint(form.errors)
+            raise SystemExit(1)
 
 
 class CreateRoleCommand(Command):

--- a/flask_security/script.py
+++ b/flask_security/script.py
@@ -15,8 +15,6 @@ try:
 except ImportError:
     import json
 
-import re
-
 from flask import current_app
 from flask_script import Command, Option
 from werkzeug.local import LocalProxy
@@ -44,15 +42,11 @@ class CreateUserCommand(Command):
     option_list = (
         Option('-e', '--email', dest='email', default=None),
         Option('-p', '--password', dest='password', default=None),
-        Option('-a', '--active', dest='active', default=''),
+        Option('-a', '--active', dest='active', action='store_true'),
     )
 
     @commit
     def run(self, **kwargs):
-        # sanitize active input
-        ai = re.sub(r'\s', '', str(kwargs['active']))
-        kwargs['active'] = ai.lower() in ['', 'y', 'yes', '1', 'active']
-
         from flask_security.forms import ConfirmRegisterForm
         from werkzeug.datastructures import MultiDict
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ Flask-SQLAlchemy>=1.0
 bcrypt>=1.0.2,<2.0.0
 flask-mongoengine>=0.7.0
 flask-peewee>=0.6.5
+Flask-Script>=2.0.5
 pymongo==2.8
 pytest>=2.5.2
 pytest-cache>=1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -210,7 +210,7 @@ def peewee_datastore(request, app, tmpdir):
 
     class User(db.Model, UserMixin):
         email = TextField()
-        username = TextField()
+        username = TextField(null=True)
         password = TextField(null=True)
         last_login_at = DateTimeField(null=True)
         current_login_at = DateTimeField(null=True)

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -55,6 +55,17 @@ def test_create_active_user(manager, datastore):
     assert user.active
 
 
+def test_create_existing_user(manager, datastore):
+    with pytest.raises(SystemExit) as excinfo:
+        manager.handle('manage', args=(
+            'create-user',
+            '--email', 'tiya@lp.com',
+            '--password', 'too many cooks',
+            '--active'))
+
+    assert excinfo.value.code != 0
+
+
 def test_toggle_user_active(manager, datastore):
     email = 'tiya@lp.com'
     user = datastore.find_user(email=email)

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+"""
+    test_script
+    ~~~~~~~~~~~~~~
+
+    Script command tests
+"""
+
+import pytest
+from flask_script import Manager
+import flask_security.script as s
+
+from utils import init_app_with_options
+
+
+commands = [
+    ('create-user', s.CreateUserCommand),
+    ('create-role', s.CreateRoleCommand),
+    ('remove-role', s.RemoveRoleCommand),
+    ('add-role', s.AddRoleCommand),
+    ('activate-user', s.ActivateUserCommand),
+    ('deactivate-user', s.DeactivateUserCommand),
+]
+
+
+@pytest.fixture
+def manager(app, datastore):
+    init_app_with_options(app, datastore)
+
+    m = Manager(app)
+    for name, cmd in commands:
+        m.add_command(name, cmd)
+
+    return m
+
+
+@pytest.mark.parametrize('command', [x for (x, y) in commands])
+def test_exits_nonzero_without_arguments(manager, datastore, command):
+    '''All the commands so far require at least one argument, so should
+    exit(nonzero) cleanly if no arguments are provided.'''
+
+    with pytest.raises(SystemExit) as excinfo:
+        manager.handle('manage', args=(command, ))
+    assert excinfo.value.code != 0
+
+
+def test_create_active_user(manager, datastore):
+    manager.handle('manage', args=(
+        'create-user',
+        '--email', 'test@example.com',
+        '--password', 'too many cooks',
+        '--active'))
+    user = datastore.find_user(email='test@example.com')
+    assert user is not None
+    assert user.active
+
+
+def test_toggle_user_active(manager, datastore):
+    email = 'tiya@lp.com'
+    user = datastore.find_user(email=email)
+    assert user is not None
+    assert not user.active
+
+    manager.handle('manage', args=(
+        'activate-user',
+        '--user', email,
+    ))
+    user = datastore.find_user(email=email)
+    assert user is not None
+    assert user.active
+
+    manager.handle('manage', args=(
+        'deactivate-user',
+        '--user', email,
+    ))
+    user = datastore.find_user(email=email)
+    assert user is not None
+    assert not user.active
+
+
+def test_create_role(manager, datastore):
+    assert datastore.find_role('cook') is None
+    manager.handle('manage', args=(
+        'create-role',
+        '--name', 'cook',
+        '--desc', 'broth artisans',
+    ))
+    role = datastore.find_role('cook')
+    assert role is not None
+    assert role.description == 'broth artisans'
+
+
+def test_toggle_role(manager, datastore):
+    email = 'tiya@lp.com'
+    role = 'admin'
+
+    user = datastore.find_user(email=email)
+    assert not user.has_role(role)
+
+    manager.handle('manage', args=(
+        'add-role',
+        '--user', email,
+        '--role', role,
+    ))
+    user = datastore.find_user(email=email)
+    assert user.has_role(role)
+
+    manager.handle('manage', args=(
+        'remove-role',
+        '--user', email,
+        '--role', role,
+    ))
+    user = datastore.find_user(email=email)
+    assert not user.has_role(role)


### PR DESCRIPTION
I wired up the commands from `flask.ext.security.script`, and discovered:
- `ActivateUserCommand` and `DeactivateUserCommand` don't work at all, as far as I can tell
- None of them fail gracefully if required parameters aren't supplied
- Passing `--active` as a flag to `CreateUserCommand` is wrong, you have to pass one of a list of undocumented parameters to mean "True"
- There are no tests

This PR fixes all except the first issue. If I get a chance I'll fix `_ToggleActiveCommand` too.
