### PR TITLE
sets form validation messages upon instantiation

### DIFF
--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -43,8 +43,7 @@ _default_field_labels = {
 
 class ValidatorMixin(object):
     def __call__(self, form, field):
-        if self.message and self.message.isupper():
-            self.message = get_message(self.message)[0]
+        set_validator_message(self)
         return super(ValidatorMixin, self).__call__(form, field)
 
 
@@ -74,6 +73,11 @@ def get_form_field_label(key):
     return _default_field_labels.get(key, '')
 
 
+def set_validator_message(validator):
+    if validator.message and validator.message.isupper():
+        validator.message = get_message(validator.message)[0]
+
+
 def unique_user_email(form, field):
     if _datastore.get_user(field.data) is not None:
         msg = get_message('EMAIL_ALREADY_ASSOCIATED', email=field.data)[0]
@@ -91,6 +95,9 @@ class Form(BaseForm):
         if current_app.testing:
             self.TIME_LIMIT = None
         super(Form, self).__init__(*args, **kwargs)
+        for field in self._fields.values():
+            for validator in field.validators:
+                set_validator_message(validator)
 
 
 class EmailFormMixin():

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -74,7 +74,7 @@ def get_form_field_label(key):
 
 
 def set_validator_message(validator):
-    if validator.message and validator.message.isupper():
+    if hasattr(validator, 'message') and validator.message.isupper():
         validator.message = get_message(validator.message)[0]
 
 


### PR DESCRIPTION
Currently, the SECURITY_MSG error messages only affect the form's validation feedback after it's been validated. However, for JavaScript libraries that access the form's validators before the form is actually submitted, the error messages that are shown are the configuration names of the messages, not the actual messages themselves. This commit sets the appropriate SECURITY_MSG messages upon instantiation of the form.
