### PR TITLE
Added IGNORE_STATIC_ENDPOINTS option

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -100,7 +100,8 @@ _default_config = {
         # And always last one...
         'plaintext'
     ],
-    'DEPRECATED_PASSWORD_SCHEMES': ['auto']
+    'DEPRECATED_PASSWORD_SCHEMES': ['auto'],
+    'IGNORE_STATIC_ENDPOINTS': False,
 }
 
 #: Default Flask-Security messages
@@ -237,7 +238,7 @@ def _get_login_manager(app, anonymous_user):
 
 
 def _get_principal(app):
-    p = Principal(app, use_sessions=False)
+    p = Principal(app, use_sessions=False, skip_static=cv('IGNORE_STATIC_ENDPOINTS'))
     p.identity_loader(_identity_loader)
     return p
 


### PR DESCRIPTION
Added option IGNORE_STATIC_ENDPOINTS that will be proxied to Principal extension.
Sometimes it is usefull (for example, if we want to have some heavy hook on identity load or request start).
