### PR TITLE
lock flask-login version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask>=0.9
-Flask-Login>=0.1.3
+Flask-Login==0.2.11
 Flask-Mail>=0.7.3
 Flask-Principal>=0.3.3
 Flask-WTF>=0.8


### PR DESCRIPTION
This locks the Flask-Login version. Given that Flask-Login is pre-1.0, library consumers should necessarily expect breaking changes even between minor point release (NB: Flask-Login keeps breaking changes to the first minor point and bug fixes to the second minor point, in terms of releases). In general, applications, i.e. consumers of libraries, are well-advised to lock their dependency versions, at least to minor point releases. By pinning an exact version, the application is ensured to yield deterministic builds--dependencies between deployments cannot vary and there are fewer variables to consider when things go awry. Here the library in question, Flask-Login, introduced numerous breaking changes in its 0.3.0 release. This means that older versions of Flask-Login are no longer compatible with 0.3.x and therefore either 0.2.x or 0.3.x must be used. Finally also note that there are numerous breaking changes between 0.1.x and 0.2.x.