### PR TITLE
master branch does not support Flask-Login >=0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask>=0.9
-Flask-Login>=0.1.3
+Flask-Login>=0.1.3,<0.3
 Flask-Mail>=0.7.3
 Flask-Principal>=0.3.3
 Flask-WTF>=0.8


### PR DESCRIPTION
If there is a minor release prior to resolving the issue upstream in #417, I believe this is the proper solution that does not break backwards compatibility.