### PR TITLE
remove dependency on flask-sqlalchemy

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -15,7 +15,7 @@ SQLAlchemy Install requirements
 ::
 
      $ mkvirtualenv <your-app-name>
-     $ pip install flask-security flask-sqlalchemy
+     $ pip install flask-security sqlalchemy
 
 
 SQLAlchemy Application
@@ -60,7 +60,7 @@ possible using SQLAlchemy:
                                 backref=db.backref('users', lazy='dynamic'))
 
     # Setup Flask-Security
-    user_datastore = SQLAlchemyUserDatastore(db, User, Role)
+    user_datastore = SQLAlchemyUserDatastore(db.session, User, Role)
     security = Security(app, user_datastore)
 
     # Create a user to test with

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -28,14 +28,14 @@ class Datastore(object):
 
 class SQLAlchemyDatastore(Datastore):
     def commit(self):
-        self.db.session.commit()
+        self.db.commit()
 
     def put(self, model):
-        self.db.session.add(model)
+        self.db.add(model)
         return model
 
     def delete(self, model):
-        self.db.session.delete(model)
+        self.db.delete(model)
 
 
 class MongoEngineDatastore(Datastore):
@@ -176,19 +176,17 @@ class UserDatastore(object):
 
 
 class SQLAlchemyUserDatastore(SQLAlchemyDatastore, UserDatastore):
-    """A SQLAlchemy datastore implementation for Flask-Security that assumes the
-    use of the Flask-SQLAlchemy extension.
-    """
+    """A SQLAlchemy datastore implementation for Flask-Security."""
     def __init__(self, db, user_model, role_model):
         SQLAlchemyDatastore.__init__(self, db)
         UserDatastore.__init__(self, user_model, role_model)
 
     def get_user(self, identifier):
         if self._is_numeric(identifier):
-            return self.user_model.query.get(identifier)
+            return self.db.query(self.user_model).get(identifier)
         for attr in get_identity_attributes():
             query = getattr(self.user_model, attr).ilike(identifier)
-            rv = self.user_model.query.filter(query).first()
+            rv = self.db.query(self.user_model).filter(query).first()
             if rv is not None:
                 return rv
 
@@ -200,10 +198,10 @@ class SQLAlchemyUserDatastore(SQLAlchemyDatastore, UserDatastore):
         return True
 
     def find_user(self, **kwargs):
-        return self.user_model.query.filter_by(**kwargs).first()
+        return self.db.query(self.user_model).filter_by(**kwargs).first()
 
     def find_role(self, role):
-        return self.role_model.query.filter_by(name=role).first()
+        return self.db.query(self.role_model).filter_by(name=role).first()
 
 
 class MongoEngineUserDatastore(MongoEngineDatastore, UserDatastore):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-Flask-SQLAlchemy>=1.0
+SQLAlchemy>=1.0
 bcrypt>=1.0.2,<2.0.0
 flask-mongoengine>=0.7.0
 flask-peewee>=0.6.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask>=0.9
-Flask-Login>=0.1.3
+Flask-Login>=0.1.3,<=0.3.0
 Flask-Mail>=0.7.3
 Flask-Principal>=0.3.3
 Flask-WTF>=0.8


### PR DESCRIPTION
It seems better to remove the dependency on flask-sqlalchemy if we can achieve exactly the same functionality without it, using plain old sqlalchemy.

Additionally, the tests now use sqlite in memory instead of file, making the test suite many times faster.

This change is currently backward incompatible, since SQLAlchemyUserDatastore now takes a  session from sqlalchemy instead of SQLAlchemy from flask-sqlalchemy. So, SQLAlchemyUserDatastore(db, User, Role) now becomes SQLAlchemyUserDatastore(db.session, User, Role). Can be made easily backward compatible, though, by adding an isinstance check (preferable), or creating a new SQLAlchemySessionUserDatastore.