### PR TITLE
Properly handle flask-login is_authenticated changes

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -20,7 +20,8 @@ from werkzeug.datastructures import ImmutableList
 from werkzeug.local import LocalProxy
 from werkzeug.security import safe_str_cmp
 
-from .utils import config_value as cv, get_config, md5, url_for_security, string_types
+from .utils import config_value as cv, get_config, is_authenticated, md5, \
+    url_for_security, string_types
 from .views import create_blueprint
 from .forms import LoginForm, ConfirmRegisterForm, RegisterForm, \
     ForgotPasswordForm, ChangePasswordForm, ResetPasswordForm, \
@@ -285,7 +286,11 @@ def _get_state(app, datastore, anonymous_user=None, **kwargs):
 
 
 def _context_processor():
-    return dict(url_for_security=url_for_security, security=_security)
+    return dict(
+        url_for_security=url_for_security,
+        security=_security,
+        security_is_authenticated=is_authenticated,
+    )
 
 
 class RoleMixin(object):

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -57,7 +57,7 @@ def _check_token():
 
     user = _security.login_manager.token_callback(token)
 
-    if user and user.is_authenticated():
+    if user and utils.is_authenticated(user):
         app = current_app._get_current_object()
         _request_ctx_stack.top.user = user
         identity_changed.send(app, identity=Identity(user.id))
@@ -138,7 +138,7 @@ def auth_required(*auth_methods):
     login_mechanisms = {
         'token': lambda: _check_token(),
         'basic': lambda: _check_http_auth(),
-        'session': lambda: current_user.is_authenticated()
+        'session': lambda: utils.is_authenticated(current_user)
     }
 
     def wrapper(fn):
@@ -220,7 +220,7 @@ def roles_accepted(*roles):
 def anonymous_user_required(f):
     @wraps(f)
     def wrapper(*args, **kwargs):
-        if current_user.is_authenticated():
+        if utils.is_authenticated(current_user):
             return redirect(utils.get_url(_security.post_login_view))
         return f(*args, **kwargs)
     return wrapper

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -384,6 +384,21 @@ def get_identity_attributes(app=None):
     return attrs
 
 
+def is_authenticated(user):
+    """Check if a user is authenticated.
+
+    :param user: the user instance to be checked
+
+    This check supports both callable and non-callable
+    ``is_authenicated`` attributes to support versions of Flask-Login
+    before and after the base UserMixin defined this as a property.
+    """
+    function = getattr(user, 'is_authenticated')
+    if callable(function):
+        return function()
+    return function
+
+
 @contextmanager
 def capture_passwordless_login_requests():
     login_requests = []

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -25,8 +25,8 @@ from .recoverable import reset_password_token_status, \
 from .changeable import change_user_password
 from .registerable import register_user
 from .utils import config_value, do_flash, get_url, get_post_login_redirect, \
-    get_post_register_redirect, get_message, login_user, logout_user, \
-    url_for_security as url_for, slash_url_suffix
+    get_post_register_redirect, get_message, is_authenticated, login_user, \
+    logout_user, url_for_security as url_for, slash_url_suffix
 
 # Convenient references
 _security = LocalProxy(lambda: current_app.extensions['security'])
@@ -90,7 +90,7 @@ def login():
 def logout():
     """View function which handles a logout request."""
 
-    if current_user.is_authenticated():
+    if is_authenticated(current_user):
         logout_user()
 
     return redirect(request.args.get('next', None) or

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,8 +3,7 @@ bcrypt>=1.0.2,<2.0.0
 flask-mongoengine>=0.7.0
 flask-peewee>=0.6.5
 pymongo==2.8
-pytest>=2.5.2
-pytest-cache>=1.0
+pytest>=2.8
 pytest-cov>=1.6
 pytest-flakes>=0.2
 pytest-pep8>=1.0.5

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ class PyTest(TestCommand):
             '--cov-report', 'term-missing',
             '--pep8',
             '--flakes',
-            '--clearcache'
+            '--cache-clear'
         ]
         self.test_suite = True
 

--- a/tests/templates/_nav.html
+++ b/tests/templates/_nav.html
@@ -1,4 +1,4 @@
-{%- if current_user.is_authenticated() -%}
+{%- if security_is_authenticated(current_user) -%}
   <p>Hello {{ current_user.email }}</p>
 {%- endif %}
 <ul>
@@ -11,7 +11,7 @@
   <li><a href="{{ url_for('admin_or_editor') }}">Admin or Editor</a></li>
   {% endif -%}
   <li>
-    {%- if current_user.is_authenticated() -%}
+    {%- if security_is_authenticated(current_user) -%}
       <a href="{{ url_for('security.logout') }}">Log out</a>
     {%- else -%}
       <a href="{{ url_for('security.login') }}">Log in</a>

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
 [tox]
-envlist = py26, py27, py33, py34, pypy
+envlist = py{26,27,33,34,py}-flask-login-{0.2,0.3}
 
 [testenv]
 deps =
-    -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements-dev.txt
+    .
+    flask-login-0.2: flask-login<0.3.0
+    flask-login-0.3: flask-login>=0.3.0
 
 commands =
     python setup.py test


### PR DESCRIPTION
As of version 0.3.0 of flask-login, the is_authenticated methods of
UserMixin and AnonymousUserMixin are properties instead of normal
methods. This change adds compatibility for both versions of these
methods.

Additionally, pytest-cache has been [merged into pytest](http://pytest.org/latest/changelog.html#id3) and is no longer
separately maintained, so pytest-cache-related requirements are being
updated.