### PR TITLE
Upgrade passlib, remove bcrypt restriction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,19 @@ cache:
   - pip
 
 install:
+  - |
+      if [ "$TRAVIS_PYTHON_VERSION" = "pypy" ]; then
+        export PYENV_ROOT="$HOME/.pyenv"
+        if [ -f "$PYENV_ROOT/bin/pyenv" ]; then
+          cd "$PYENV_ROOT" && git pull
+        else
+          rm -rf "$PYENV_ROOT" && git clone --depth 1 https://github.com/yyuu/pyenv.git "$PYENV_ROOT"
+        fi
+        export PYPY_VERSION="4.0.1"
+        "$PYENV_ROOT/bin/pyenv" install "pypy-$PYPY_VERSION"
+        virtualenv --python="$PYENV_ROOT/versions/pypy-$PYPY_VERSION/bin/python" "$HOME/virtualenvs/pypy-$PYPY_VERSION"
+        source "$HOME/virtualenvs/pypy-$PYPY_VERSION/bin/activate"
+      fi
   - pip install -r requirements.txt -r requirements-dev.txt -e .
   - pip install coverage coveralls
   - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install importlib; fi"

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -23,10 +23,7 @@ Core
                                          passwords. Recommended values for
                                          production systems are ``bcrypt``,
                                          ``sha512_crypt``, or ``pbkdf2_sha512``.
-                                         Defaults to ``plaintext``. Note:
-                                         ``bcrypt>=2.0.0`` is not currently
-                                         supported. If ``bcrypt`` is preferred,
-                                         please use ``bcrypt<2.0``.
+                                         Defaults to ``plaintext``.
 ``SECURITY_PASSWORD_SALT``               Specifies the HMAC salt. This is only
                                          used if the password hash type is set
                                          to something other than plain text.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 Flask-SQLAlchemy>=1.0
-bcrypt>=1.0.2,<2.0.0
+bcrypt>=1.0.2
 flask-mongoengine>=0.7.0,<0.7.3
 flask-peewee>=0.6.5
 pymongo==2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ Flask-Mail>=0.7.3
 Flask-Principal>=0.3.3
 Flask-WTF>=0.8
 itsdangerous>=0.17
-passlib>=1.6.1
+passlib>=1.6.4


### PR DESCRIPTION
Due to a bug in passlib [0], use of bcrypt>=0.2.0 was not working
properly. As of passlib==1.6.4, that bug is fixed [1]. The minimum
required version of passlib is upgraded to 1.6.4 to address this issue
and properly support current versions of bcrypt. Because pypy is
outdated on travis [2,3], a fix [4] to bring it up to date is needed
(locally, tests pass with pypy >= 2.6 but not 2.5, the current version
used on travis).

[0] https://bitbucket.org/ecollins/passlib/issues/56
[1] https://bitbucket.org/ecollins/passlib/src/fa26802fc88fbc6b2d4b9676970bed7e6d53fc9d/CHANGES?at=default&fileviewer=file-view-default#CHANGES-130,131
[2] https://github.com/travis-ci/travis-ci/issues/4756
[3] https://github.com/travis-ci/travis-ci/issues/5027
[4] https://github.com/travis-ci/travis-ci/issues/5027#issuecomment-170939193