### PR TITLE
Add option URL_SCHEME

### DIFF
--- a/flask_security/confirmable.py
+++ b/flask_security/confirmable.py
@@ -27,7 +27,9 @@ _datastore = LocalProxy(lambda: _security.datastore)
 
 def generate_confirmation_link(user):
     token = generate_confirmation_token(user)
-    return url_for_security('confirm_email', token=token, _external=True), token
+    return url_for_security(
+        'confirm_email', token=token, _external=True,
+        _scheme=config_value('URL_SCHEME')), token
 
 
 def send_confirmation_instructions(user):

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -34,6 +34,7 @@ _security = LocalProxy(lambda: current_app.extensions['security'])
 _default_config = {
     'BLUEPRINT_NAME': 'security',
     'URL_PREFIX': None,
+    'URL_SCHEME': 'http',
     'SUBDOMAIN': None,
     'FLASH_MESSAGES': True,
     'PASSWORD_HASH': 'plaintext',

--- a/flask_security/passwordless.py
+++ b/flask_security/passwordless.py
@@ -30,7 +30,9 @@ def send_login_instructions(user):
     :param token: The login token
     """
     token = generate_login_token(user)
-    login_link = url_for_security('token_login', token=token, _external=True)
+    login_link = url_for_security(
+        'token_login', token=token, _external=True,
+        _scheme=config_value('URL_SCHEME'))
 
     send_mail(config_value('EMAIL_SUBJECT_PASSWORDLESS'), user.email,
               'login_instructions', user=user, login_link=login_link)

--- a/flask_security/recoverable.py
+++ b/flask_security/recoverable.py
@@ -30,7 +30,9 @@ def send_reset_password_instructions(user):
     :param user: The user to send the instructions to
     """
     token = generate_reset_password_token(user)
-    reset_link = url_for_security('reset_password', token=token, _external=True)
+    reset_link = url_for_security(
+        'reset_password', token=token, _external=True,
+        _scheme=config_value('URL_SCHEME'))
 
     send_mail(config_value('EMAIL_SUBJECT_PASSWORD_RESET'), user.email,
               'reset_instructions',

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -208,6 +208,8 @@ def url_for_security(endpoint, **values):
     :param _external: if set to `True`, an absolute URL is generated. Server
       address can be changed via `SERVER_NAME` configuration variable which
       defaults to `localhost`.
+    :param _scheme: a string specifying the desired URL scheme. The `_external`
+      parameter must be set to `True` or a `ValueError` is raised.
     :param _anchor: if provided this is added as anchor to the URL.
     :param _method: if provided this explicitly specifies an HTTP method.
     """


### PR DESCRIPTION
This option can be used to set url scheme to **https**.

I deployed a flask app which only accepts https requests and got a connection issue when I tried to reset password by the instruction sent to me since the link in that email was generated with scheme 'http'.

So I'm trying to fix this issue by this PR.