### PR TITLE
Remove a duplicate line 

### DIFF
--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -29,7 +29,6 @@ _default_field_labels = {
     'password': 'Password',
     'remember_me': 'Remember Me',
     'login': 'Login',
-    'retype_password': 'Retype Password',
     'register': 'Register',
     'send_confirmation': 'Resend Confirmation Instructions',
     'recover_password': 'Recover Password',


### PR DESCRIPTION
Removed from `_default_field_labels` (forms.py) a duplicate definition of `'retype_password': 'Retype Password'` (left in line 36)