### PR TITLE
Fix tests, add py35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,20 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
   - "pypy"
 
 install:
   - pip install -r requirements.txt -r requirements-dev.txt -e .
   - pip install coverage coveralls
   - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install importlib; fi"
+
+addons:
+  apt:
+    sources:
+      - deadsnakes
+    packages:
+      - python3.5
 
 services:
   - mongodb

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,9 @@
 Flask-SQLAlchemy>=1.0
 bcrypt>=1.0.2,<2.0.0
-flask-mongoengine>=0.7.0
+flask-mongoengine>=0.7.0,<0.7.3
 flask-peewee>=0.6.5
 pymongo==2.8
 pytest>=2.5.2
-pytest-cache>=1.0
 pytest-cov>=1.6
 pytest-flakes>=0.2
 pytest-pep8>=1.0.5

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ class PyTest(TestCommand):
             '--cov-report', 'term-missing',
             '--pep8',
             '--flakes',
-            '--clearcache'
+            '--cache-clear'
         ]
         self.test_suite = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, pypy
+envlist = py26, py27, py33, py34, py35, pypy
 
 [testenv]
 deps =


### PR DESCRIPTION
- Add Python 3.5 support on travis

- pytest-cache has been merged into pytest [0] and is no longer
  separately maintained, so pytest-cache-related requirements are being
  updated.

- Flask-Mongoengine latest stable is broken on Python 2.6 (but fixed in
  master [1]), so its version is being restricted for now.

[0] http://pytest.org/latest/changelog.html#id3
[1] https://github.com/MongoEngine/flask-mongoengine/pull/174