### PR TITLE
Add support for a SECURITY_BCRYPT_ROUNDS setting.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -53,6 +53,8 @@ Core
 ``SECURITY_DEPRECATED_HASHING_SCHEMES``  List of deprecated algorithms used for
                                          creating and validating tokens.
                                          Defaults to ``hex_md5``.
+``SECURITY_PASSWORD_HASH_OPTIONS``       Specifies additional options to be passed
+                                         to the hashing method.
 ``SECURITY_EMAIL_SENDER``                Specifies the email address to send
                                          emails as. Defaults to value set
                                          to ``MAIL_DEFAULT_SENDER`` if

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -192,7 +192,12 @@ def hash_password(password):
     """
     if use_double_hash():
         password = get_hmac(password).decode('ascii')
-    return _pwd_context.hash(password)
+
+    return _pwd_context.hash(
+        password,
+        **config_value('PASSWORD_HASH_OPTIONS', default={}).get(
+            _security.password_hash, {})
+    )
 
 
 def encode_string(string):

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -32,6 +32,16 @@ def test_verify_password_bcrypt_single_hash(app, sqlalchemy_datastore):
         assert verify_password('pass', encrypt_password('pass'))
 
 
+def test_verify_password_bcrypt_rounds_too_low(app, sqlalchemy_datastore):
+    with raises(ValueError) as exc_msg:
+        init_app_with_options(app, sqlalchemy_datastore, **{
+            'SECURITY_PASSWORD_HASH': 'bcrypt',
+            'SECURITY_PASSWORD_SALT': 'salty',
+            'SECURITY_PASSWORD_HASH_OPTIONS': {'bcrypt': {'rounds': 3}}
+        })
+    assert all(s in str(exc_msg) for s in ['rounds', 'too low'])
+
+
 def test_login_with_bcrypt_enabled(app, sqlalchemy_datastore):
     init_app_with_options(app, sqlalchemy_datastore, **{
         'SECURITY_PASSWORD_HASH': 'bcrypt',


### PR DESCRIPTION
Allows the usage of a variable number of rounds when using bcrypt. Set
the rounds to 4 in test_hashing.py, and add a test for an invalid number of
rounds (e.g. 3).
#426
