### PR TITLE
DISABLE_ENCRYPTION option

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -268,6 +268,10 @@ Miscellaneous
 ``SECURITY_DEFAULT_REMEMBER_ME``              Specifies the default "remember
                                               me" value used when logging in
                                               a user. Defaults to ``False``.
+``SECURITY_DISABLE_ENCRYPTION``               Disables encryption (i.e. for
+                                              use with SQLAlchemy-Utils' 
+                                              PasswordType). Defaults to ``False``
+
 ============================================= ==================================
 
 Messages

--- a/flask_security/changeable.py
+++ b/flask_security/changeable.py
@@ -39,7 +39,8 @@ def change_user_password(user, password):
     :param user: The user to change_password
     :param password: The unencrypted new password
     """
-    user.password = encrypt_password(password)
+    if not config_value('DISABLE_ENCRYPTION'):
+        user.password = encrypt_password(password)
     _datastore.put(user)
     send_password_changed_notice(user)
     password_changed.send(app._get_current_object(),

--- a/flask_security/recoverable.py
+++ b/flask_security/recoverable.py
@@ -84,7 +84,8 @@ def update_password(user, password):
     :param user: The user to update_password
     :param password: The unencrypted new password
     """
-    user.password = encrypt_password(password)
+    if not config_value('DISABLE_ENCRYPTION'):
+        user.password = encrypt_password(password)
     _datastore.put(user)
     send_password_reset_notice(user)
     password_reset.send(app._get_current_object(), user=user)

--- a/flask_security/registerable.py
+++ b/flask_security/registerable.py
@@ -25,7 +25,8 @@ _datastore = LocalProxy(lambda: _security.datastore)
 
 def register_user(**kwargs):
     confirmation_link, token = None, None
-    kwargs['password'] = encrypt_password(kwargs['password'])
+    if not config_value('DISABLE_ENCRYPTION'):
+        kwargs['password'] = encrypt_password(kwargs['password'])
     user = _datastore.create_user(**kwargs)
     _datastore.commit()
 

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -131,7 +131,7 @@ def verify_and_update_password(password, user):
     :param user: The user to verify against
     """
     if config_value('DISABLE_ENCRYPTION'):
-        return password == user.password        
+        return password == user.password
     if _pwd_context.identify(user.password) != 'plaintext':
         password = get_hmac(password)
     verified, new_password = _pwd_context.verify_and_update(password, user.password)

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -130,7 +130,8 @@ def verify_and_update_password(password, user):
     :param password: A plaintext password to verify
     :param user: The user to verify against
     """
-
+    if config_value('DISABLE_ENCRYPTION'):
+        return password == user.password        
     if _pwd_context.identify(user.password) != 'plaintext':
         password = get_hmac(password)
     verified, new_password = _pwd_context.verify_and_update(password, user.password)


### PR DESCRIPTION
I use the wonderful [SQLAlchemy-Utils](http://sqlalchemy-utils.readthedocs.org/en/latest/data_types.html) library which transparently handles password encryption in your database models. However, because this is not a String, but rather a PasswordType it is not compatible with Flask-Security's encryption engine, even when set on 'plaintext'. This gives the option to disable encryption entirely.