### PR TITLE
utils: use `None` instead of 'untrackable' for IPs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,6 +22,7 @@ Eric Butler
 Eskil Heyn Olsen
 Iuri de Silvio
 Jay Goel
+Jiri Kuncar
 Joe Esposito
 Joe Hand
 Josh Purvis

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -65,14 +65,14 @@ def login_user(user, remember=None):
         if 'X-Forwarded-For' in request.headers:
             remote_addr = request.headers.getlist("X-Forwarded-For")[0].rpartition(' ')[-1]
         else:
-            remote_addr = request.remote_addr or 'untrackable'
+            remote_addr = request.remote_addr or None  # make sure it is None and not ''
 
         old_current_login, new_current_login = user.current_login_at, datetime.utcnow()
         old_current_ip, new_current_ip = user.current_login_ip, remote_addr
 
         user.last_login_at = old_current_login or new_current_login
         user.current_login_at = new_current_login
-        user.last_login_ip = old_current_ip or new_current_ip
+        user.last_login_ip = old_current_ip
         user.current_login_ip = new_current_ip
         user.login_count = user.login_count + 1 if user.login_count else 1
 

--- a/tests/test_trackable.py
+++ b/tests/test_trackable.py
@@ -23,7 +23,7 @@ def test_trackable_flag(app, client):
         user = app.security.datastore.find_user(email=e)
         assert user.last_login_at is not None
         assert user.current_login_at is not None
-        assert user.last_login_ip == 'untrackable'
+        assert user.last_login_ip is None
         assert user.current_login_ip == '127.0.0.1'
         assert user.login_count == 2
 
@@ -39,6 +39,6 @@ def test_trackable_with_multiple_ips_in_headers(app, client):
         user = app.security.datastore.find_user(email=e)
         assert user.last_login_at is not None
         assert user.current_login_at is not None
-        assert user.last_login_ip == 'untrackable'
+        assert user.last_login_ip is None
         assert user.current_login_ip == '88.88.88.88'
         assert user.login_count == 2


### PR DESCRIPTION
Changes trackable behavior of `login_user` when IP can not be detected
from a request from 'untrackable' to `None` value.  (closes #448)
