### PR TITLE
views: allow rendering json forms when form.user is unset

### DIFF
--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -43,9 +43,10 @@ def _render_json(form, include_user=True, include_auth_token=False):
     else:
         code = 200
         response = dict()
-        if include_user:
+        has_user = hasattr(form, 'user') and form.user
+        if include_user and has_user:
             response['user'] = dict(id=str(form.user.id))
-        if include_auth_token:
+        if include_auth_token and has_user:
             token = form.user.get_auth_token()
             response['user']['authentication_token'] = token
 


### PR DESCRIPTION
Doing a GET against /security/login with content-type: application/json
results in a traceback because form.user is accessed sans checking for
existence.

Make the request succeed by checking for the user before accessing its
fields.  A subsequent commit will make this useful in other situations.

Related-to: #421
Signed-off-by: David Aguilar davvid@gmail.com
