### PR TITLE
views: allow adding a csrf token to json responses

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -47,6 +47,13 @@ Core
 ``SECURITY_DEFAULT_HTTP_AUTH_REALM``     Specifies the default authentication
                                          realm when using basic HTTP auth.
                                          Defaults to ``Login Required``
+``SECURITY_JSON_INCLUDE_CSRF``           Specifies if CSRF tokens are included
+                                         in json responses. This allows
+                                         clients to pass Flask-WTF's CSRF
+                                         protection by including its value as
+                                         the ``X-CSRFToken`` header when making
+                                         application/json requests.
+                                         Defaults to ``False``.
 ======================================== =======================================
 
 

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -76,6 +76,7 @@ _default_config = {
     'TOKEN_AUTHENTICATION_KEY': 'auth_token',
     'TOKEN_AUTHENTICATION_HEADER': 'Authentication-Token',
     'TOKEN_MAX_AGE': None,
+    'JSON_INCLUDE_CSRF': False,
     'CONFIRM_SALT': 'confirm-salt',
     'RESET_SALT': 'reset-salt',
     'LOGIN_SALT': 'login-salt',

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -12,6 +12,7 @@
 from flask import current_app, redirect, request, jsonify, \
     after_this_request, Blueprint
 from flask_login import current_user
+from flask_wtf import csrf
 from werkzeug.datastructures import MultiDict
 from werkzeug.local import LocalProxy
 
@@ -49,6 +50,8 @@ def _render_json(form, include_user=True, include_auth_token=False):
         if include_auth_token and has_user:
             token = form.user.get_auth_token()
             response['user']['authentication_token'] = token
+        if _security.json_include_csrf:
+            response['csrf_token'] = csrf.generate_csrf()
 
     return jsonify(dict(meta=dict(code=code), response=response))
 

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -43,9 +43,10 @@ def _render_json(form, include_user=True, include_auth_token=False):
     else:
         code = 200
         response = dict()
-        if include_user:
+        has_user = hasattr(form, 'user') and form.user
+        if include_user and has_user:
             response['user'] = dict(id=str(form.user.id))
-        if include_auth_token:
+        if include_auth_token and has_user:
             token = form.user.get_auth_token()
             response['user']['authentication_token'] = token
 


### PR DESCRIPTION
flask-wtf's CsrfProtect makes it hard to use flask-security with json
requests because a csrf token is needed when posting json data.

This difficulty can be alleviated by teaching flask-security
provide a csrf token in its responses.

Teach _render_json() to supply a csrf_token value in the response when
the SECURITY_JSON_INCLUDE_CSRF configuration is True.  The presence
of csrf_token allows clients to respond back with the X-CSRFToken
header set to its value.  This allows flask-security json
requests to work without needing to disable csrf.

Related-to: #421
Signed-off-by: David Aguilar davvid@gmail.com
