### PR TITLE
core: fix infinite recursion in __getattr__

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -280,3 +280,15 @@ def test_custom_forms_via_config(app, sqlalchemy_datastore):
 def test_without_babel(client):
     response = client.get('/login')
     assert b'Login' in response.data
+
+
+def test_getattr_with_app_constructor(app, sqlalchemy_datastore):
+    security = Security(app=app, datastore=sqlalchemy_datastore)
+    assert security.flash_messages is True
+
+
+def test_getattr_with_default_constructor(app, sqlalchemy_datastore):
+    security = Security(datastore=sqlalchemy_datastore)
+    security.init_app(app)
+    with app.app_context():
+        assert security.flash_messages is True


### PR DESCRIPTION
The intention of **getattr** is to return the value from the internal
state.  When using the factory pattern, the instance's _state is never
set, so __getattr__ fails:

```
flask_security/core.py:453: in __getattr__
    return getattr(self._state, name, None)
!!! Recursion detected (same locals & position)
```

We can make both use cases work by providing a default _state that
points to the security local proxy at the class level.  This allows the
immediate-constructor Security(app) form to override the class attribute
in the instance, as it currently does, while also allowing
__getattr__ to succeed when using the factory pattern.

Add tests to exercise both the existing and newly-fixed behaviors.

Related-to: #317
Signed-off-by: David Aguilar davvid@gmail.com
