### PR TITLE
fix security.init_app(app) usage by setting self._state

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -423,7 +423,7 @@ class Security(object):
 
         identity_loaded.connect_via(app)(_on_identity_loaded)
 
-        state = _get_state(app, datastore,
+        self._state = _get_state(app, datastore,
                            login_form=login_form,
                            confirm_register_form=confirm_register_form,
                            register_form=register_form,
@@ -435,11 +435,11 @@ class Security(object):
                            anonymous_user=anonymous_user)
 
         if register_blueprint:
-            app.register_blueprint(create_blueprint(state, __name__))
+            app.register_blueprint(create_blueprint(self._state, __name__))
             app.context_processor(_context_processor)
 
         state.render_template = self.render_template
-        app.extensions['security'] = state
+        app.extensions['security'] = self._state
 
         return state
 


### PR DESCRIPTION
Bugfix: `security.init_app(app)` doesn't match `security = Security(app)` as the first doesn't set security._state while the second does. This change fixes that.

Without this change `security.send_mail_task` will give an infinite recursion error.
