### PR TITLE
Allow non-email check_http_auth

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -75,6 +75,7 @@ _default_config = {
     'EMAIL_SENDER': 'no-reply@localhost',
     'TOKEN_AUTHENTICATION_KEY': 'auth_token',
     'TOKEN_AUTHENTICATION_HEADER': 'Authentication-Token',
+    'TOKEN_MAX_AGE': None,
     'CONFIRM_SALT': 'confirm-salt',
     'RESET_SALT': 'reset-salt',
     'LOGIN_SALT': 'login-salt',
@@ -192,7 +193,7 @@ def _user_loader(user_id):
 
 def _token_loader(token):
     try:
-        data = _security.remember_token_serializer.loads(token)
+        data = _security.remember_token_serializer.loads(token, max_age=_security.token_max_age)
         user = _security.datastore.find_user(id=data[0])
         if user and safe_str_cmp(md5(user.password), data[1]):
             return user

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -67,7 +67,7 @@ def _check_token():
 
 def _check_http_auth():
     auth = request.authorization or BasicAuth(username=None, password=None)
-    user = _security.datastore.find_user(email=auth.username)
+    user = _security.datastore.get_user(auth.username)
 
     if user and utils.verify_and_update_password(auth.password, user):
         _security.datastore.commit()


### PR DESCRIPTION
Should be using `get_user` instead of `find_user`. The `get_user` is more flexible in that it does not require username to be an email. 