### PR TITLE
Only flash CONFIRM_REGISTRATION if email is sent.

### DIFF
--- a/flask_security/registerable.py
+++ b/flask_security/registerable.py
@@ -31,7 +31,6 @@ def register_user(**kwargs):
 
     if _security.confirmable:
         confirmation_link, token = generate_confirmation_link(user)
-        do_flash(*get_message('CONFIRM_REGISTRATION', email=user.email))
 
     user_registered.send(app._get_current_object(),
                          user=user, confirm_token=token)
@@ -39,5 +38,8 @@ def register_user(**kwargs):
     if config_value('SEND_REGISTER_EMAIL'):
         send_mail(config_value('EMAIL_SUBJECT_REGISTER'), user.email, 'welcome',
                   user=user, confirmation_link=confirmation_link)
+        if confirmation_link:
+            do_flash(*get_message('CONFIRM_REGISTRATION', email=user.email))
+
 
     return user


### PR DESCRIPTION
This PR is likely to be rejected and that's fine--I actually don't think it's an ideal fix, but it's something at least. (I'm also submitting this PR through github's website UI, which means I haven't run tests or anything... sorry!)

Basically, the problem I noticed was that I set `SECURITY_CONFIRMABLE` to `True`, yet unbeknownst to me, my app's config already had `SECURITY_SEND_REGISTER_EMAIL` set to `False`. Because of the way flask-security implements things, the confirmation link wasn't being sent, yet `CONFIRM_REGISTRATION` was still being flashed!

This PR changes things so that `CONFIRM_REGISTRATION` only flashes if an email was actually sent (since otherwise the flash message would be lying). I'm not sure if this is an ideal fix, though, since it still means that apps with the following configuration will still effectively prevent new users from logging in at all:

```python
SECURITY_SEND_REGISTER_EMAIL=False
SECURITY_CONFIRMABLE=True
SECURITY_LOGIN_WITHOUT_CONFIRMATION=False
```

I'm not sure what the best fix here would be. One possibility is to accept the behavior in this PR, but also raise a helpful error if the above mis-configuration is provided.