### PR TITLE
Fix Flask-Script ActivateUserCommand and DeactivateUserCommand

### DIFF
--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -67,9 +67,13 @@ class UserDatastore(object):
         self.user_model = user_model
         self.role_model = role_model
 
-    def _prepare_role_modify_args(self, user, role):
+    def _prepare_user_modify_args(self, user):
         if isinstance(user, string_types):
             user = self.find_user(email=user)
+        return user
+
+    def _prepare_role_modify_args(self, user, role):
+        user = self._prepare_user_modify_args(user)
         if isinstance(role, string_types):
             role = self.find_role(role)
         return user, role
@@ -125,6 +129,7 @@ class UserDatastore(object):
 
     def toggle_active(self, user):
         """Toggles a user's active status. Always returns True."""
+        user = self._prepare_user_modify_args(user)
         user.active = not user.active
         return True
 
@@ -133,6 +138,7 @@ class UserDatastore(object):
 
         :param user: The user to deactivate
         """
+        user = self._prepare_user_modify_args(user)
         if user.active:
             user.active = False
             return True
@@ -143,6 +149,7 @@ class UserDatastore(object):
 
         :param user: The user to activate
         """
+        user = self._prepare_user_modify_args(user)
         if not user.active:
             user.active = True
             return True
@@ -172,6 +179,7 @@ class UserDatastore(object):
 
         :param user: The user to delete
         """
+        user = self._prepare_user_modify_args(user)
         self.delete(user)
 
 


### PR DESCRIPTION
Currently, the datastore only accepts user instances as arguments to `toggle_active`, `deactivate_user`, `activate_user` and `delete_user` methods.

It doesn't accept user identifiers (typically, a string containing the e-mail address), except in the `add_role_to_user` and `remove_role_from_user` methods.

This is why you can't execute some Flask-Script commands.

You can add a role:

``` console
$ ./manage.py add_role -u admin@localhost -r admin
Role 'admin' added to user 'admin@localhost' successfully
```

But you can't activate a user:

``` console
$ ./manage.py activate_user -u admin@localhost
Traceback (most recent call last):
  File "./manage.py", line 45, in <module>
    manager.run()
  File "/.../lib/python2.7/site-packages/flask_script/__init__.py", line 412, in run
    result = self.handle(sys.argv[0], sys.argv[1:])
  File "/.../lib/python2.7/site-packages/flask_script/__init__.py", line 383, in handle
    res = handle(*args, **config)
  File "/.../lib/python2.7/site-packages/flask_script/commands.py", line 216, in __call__
    return self.run(*args, **kwargs)
  File "/.../flask-security/flask_security/script.py", line 36, in wrapper
    fn(*args, **kwargs)
  File "/.../flask-security/flask_security/script.py", line 131, in run
    _datastore.activate_user(user_identifier)
  File "/.../flask-security/flask_security/datastore.py", line 146, in activate_user
    if not user.active:
AttributeError: 'str' object has no attribute 'active'
```

After applying this patch, everything works as expected:

``` console
$ ./manage.py activate_user -u admin@localhost
User 'admin@localhost' has been activated
```

A simple `manage.py` test file:

``` python
from flask.ext.script import Manager
from flask.ext.security import script as security_script

app = ...

manager = Manager(app)
manager.add_command("create_user", security_script.CreateUserCommand())
manager.add_command("activate_user", security_script.ActivateUserCommand())
manager.add_command("deactivate_user", security_script.DeactivateUserCommand())
manager.add_command("create_role", security_script.CreateRoleCommand())
manager.add_command("add_role", security_script.AddRoleCommand())
manager.add_command("remove_role", security_script.RemoveRoleCommand())

if __name__ == "__main__":
    manager.run()
```
