### PR TITLE
Add config option to skip sending password reset email

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -231,6 +231,9 @@ Miscellaneous
 ``SECURITY_SEND_PASSWORD_CHANGE_EMAIL``       Specifies whether password change
                                               email is sent. Defaults to
                                               ``True``.
+``SECURITY_SEND_PASSWORD_RESET_EMAIL``        Specifies whether password reset
+                                              email is sent. Defaults to
+                                              ``True``.
 ``SECURITY_SEND_PASSWORD_RESET_NOTICE_EMAIL`` Specifies whether password reset
                                               notice email is sent. Defaults to
                                               ``True``.

--- a/flask_security/confirmable.py
+++ b/flask_security/confirmable.py
@@ -34,7 +34,6 @@ def send_confirmation_instructions(user):
     """Sends the confirmation instructions email for the specified user.
 
     :param user: The user to send the instructions to
-    :param token: The confirmation token
     """
 
     confirmation_link, token = generate_confirmation_link(user)
@@ -43,8 +42,8 @@ def send_confirmation_instructions(user):
               'confirmation_instructions', user=user,
               confirmation_link=confirmation_link)
 
-    confirm_instructions_sent.send(app._get_current_object(), user=user)
-    return token
+    confirm_instructions_sent.send(app._get_current_object(), user=user,
+                                   token=token)
 
 
 def generate_confirmation_token(user):

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -67,6 +67,7 @@ _default_config = {
     'CHANGEABLE': False,
     'SEND_REGISTER_EMAIL': True,
     'SEND_PASSWORD_CHANGE_EMAIL': True,
+    'SEND_PASSWORD_RESET_EMAIL': True,
     'SEND_PASSWORD_RESET_NOTICE_EMAIL': True,
     'LOGIN_WITHIN': '1 days',
     'CONFIRM_EMAIL_WITHIN': '5 days',

--- a/flask_security/recoverable.py
+++ b/flask_security/recoverable.py
@@ -32,9 +32,10 @@ def send_reset_password_instructions(user):
     token = generate_reset_password_token(user)
     reset_link = url_for_security('reset_password', token=token, _external=True)
 
-    send_mail(config_value('EMAIL_SUBJECT_PASSWORD_RESET'), user.email,
-              'reset_instructions',
-              user=user, reset_link=reset_link)
+    if config_value('SEND_PASSWORD_RESET_EMAIL'):
+        send_mail(config_value('EMAIL_SUBJECT_PASSWORD_RESET'), user.email,
+                  'reset_instructions',
+                  user=user, reset_link=reset_link)
 
     reset_password_instructions_sent.send(app._get_current_object(), user=user, token=token)
 

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -13,7 +13,7 @@ import pytest
 from flask import Flask
 from flask_security.core import UserMixin
 from flask_security.signals import user_confirmed, confirm_instructions_sent
-from flask_security.utils import capture_registrations
+from flask_security.utils import capture_registrations, string_types
 
 from utils import authenticate, logout
 
@@ -32,9 +32,10 @@ def test_confirmable_flag(app, client, sqlalchemy_datastore, get_message):
         recorded_confirms.append(user)
 
     @confirm_instructions_sent.connect_via(app)
-    def on_instructions_sent(app, user):
+    def on_instructions_sent(app, user, token):
         assert isinstance(app, Flask)
         assert isinstance(user, UserMixin)
+        assert isinstance(token, string_types)
         recorded_instructions_sent.append(user)
 
     # Test login before confirmation


### PR DESCRIPTION
My app hooks into the Flask Security signals to send email via a different method. This change means the password reset emails can be disabled to achieve this.

Second commit also passes the token to the `confirm_instructions` signal.
