### PR TITLE
Cascade PeeweeDatastore delete

### DIFF
--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -53,7 +53,7 @@ class PeeweeDatastore(Datastore):
         return model
 
     def delete(self, model):
-        model.delete_instance()
+        model.delete_instance(recursive=True)
 
 
 class UserDatastore(object):


### PR DESCRIPTION
Make sure `PeeweeUserDatastore.delete_user()` also deletes related `UserRoles` records.
It's a potential vulnerability (a future user might gain unintended roles if the id is reused), and the delete might even fail if `User` has other constraints (e.g. a profile record).
