### PR TITLE
Fix SQLAlchemy get_user(..) allowing wildcards.

### DIFF
--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -187,7 +187,8 @@ class SQLAlchemyUserDatastore(SQLAlchemyDatastore, UserDatastore):
         if self._is_numeric(identifier):
             return self.user_model.query.get(identifier)
         for attr in get_identity_attributes():
-            query = getattr(self.user_model, attr).ilike(identifier)
+            identifier = identifier.replace('_', '\_').replace('%', '\%')
+            query = getattr(self.user_model, attr).ilike(identifier, '\\')
             rv = self.user_model.query.filter(query).first()
             if rv is not None:
                 return rv


### PR DESCRIPTION
Potential fix for #513 under the assumption wildcards aren't an intended feature of `SQLAlchemyUserDatastore.get_user(...)`.