### PR TITLE
Support passwordless JSON logins

### DIFF
--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -437,3 +437,12 @@ def capture_reset_password_requests(reset_password_sent_at=None):
         yield reset_requests
     finally:
         reset_password_instructions_sent.disconnect(_on)
+
+
+def request_wants_json():
+    ''' stolen from http://flask.pocoo.org/snippets/45/ '''
+    best = request.accept_mimetypes \
+        .best_match(['application/json', 'text/html'])
+    return best == 'application/json' and \
+        request.accept_mimetypes[best] > \
+        request.accept_mimetypes['text/html']

--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -7,6 +7,7 @@
 """
 
 import time
+import json
 
 import pytest
 
@@ -77,6 +78,19 @@ def test_trackable_flag(app, client, get_message):
     response = client.post('/login', data=dict(email='bogus@bogus.com'))
     assert get_message('USER_DOES_NOT_EXIST') in response.data
 
+    # Test json based failed login
+    response = client.get('/login/bogus',
+                          headers=dict(Accept="application/json"))
+    assert get_message('INVALID_LOGIN_TOKEN') in response.data
+
+    # Test json based login
+    response = client.get('/login/' + token,
+                          headers=dict(Accept="application/json"))
+    assert 'next' in response.data
+    response_user = json.loads(response.data)['response']['user']
+    assert 'authentication_token' in response_user
+
+    logout(client)
 
 @pytest.mark.settings(login_within='1 milliseconds')
 def test_expired_login_token(client, app, get_message):


### PR DESCRIPTION
Only the first phase of the passwordless login supported JSON based requests.
The login itself, usually done by clicking on the link in the login email,
supported only html requests and always responded with a `Set-Cookie` header.
Now the login itself can be sent with `application/json` in the `Accept` header
resulting in a JSON response that contains `authorization_token` in the
`user` attribute contained in the `response` attribute.