### PR TITLE
Implements basic ldap auth

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -90,6 +90,13 @@ _default_config = {
     'EMAIL_SUBJECT_PASSWORD_CHANGE_NOTICE': 'Your password has been changed',
     'EMAIL_SUBJECT_PASSWORD_RESET': 'Password reset instructions',
     'USER_IDENTITY_ATTRIBUTES': ['email'],
+    'LDAP_URI': None,
+    'LDAP_BASE_DN': None,
+    'LDAP_SEARCH_FILTER': "(uid={})",
+    'LDAP_BIND_DN': "",
+    'LDAP_BIND_PASSWORD': "",
+    'LDAP_EMAIL_FIELDNAME': "mailSenderAddress",
+    'LDAP_ACTIVE_FIELDNAME': "accountStatus",
     'PASSWORD_SCHEMES': [
         'bcrypt',
         'des_crypt',
@@ -148,6 +155,8 @@ _default_messages = {
         'Account is disabled.', 'error'),
     'EMAIL_NOT_PROVIDED': (
         'Email not provided', 'error'),
+    'USERID_NOT_PROVIDED': (
+        'User ID not provided', 'error'),
     'INVALID_EMAIL_ADDRESS': (
         'Invalid email address', 'error'),
     'PASSWORD_NOT_PROVIDED': (

--- a/flask_security/ldap/__init__.py
+++ b/flask_security/ldap/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""
+    flask_security.ldap
+    ~~~~~~~~~~~~~~~~~~~
+
+    Flask-Security ldap module
+
+    :copyright: (c) 2012 by Matt Wright.
+    :license: MIT, see LICENSE for more details.
+"""
+
+from .datastore import LDAPUserDatastore
+from .forms import LDAPLoginForm

--- a/flask_security/ldap/datastore.py
+++ b/flask_security/ldap/datastore.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""
+    flask_security.ldap.datastore
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Flask-Security ldap datastore module
+
+    :copyright: (c) 2012 by Matt Wright.
+    :license: MIT, see LICENSE for more details.
+"""
+
+import six
+import ldap
+
+from ..datastore import SQLAlchemyUserDatastore
+from ..utils import config_value
+
+
+class LDAPUserDatastore(SQLAlchemyUserDatastore):
+    def __init__(self, db, user_model, role_model):
+        SQLAlchemyUserDatastore.__init__(self, db, user_model, role_model)
+
+    def _get_ldap_con(self):
+        con = ldap.initialize(six.u(config_value("LDAP_URI")),
+                              bytes_mode=False)
+        con.simple_bind_s(six.u(config_value("LDAP_BIND_DN")),
+                          six.u(config_value("LDAP_BIND_PASSWORD")))
+        return con
+
+    def _close_ldap_con(self, con):
+        con.unbind_s()
+
+    def query_ldap_user(self, identifier):
+        con = self._get_ldap_con()
+        results = con.search_s(
+            six.u(config_value("LDAP_BASE")), ldap.SCOPE_SUBTREE,
+            six.u(config_value("LDAP_SEARCH_FILTER")).format(identifier)
+        )
+        self._close_ldap_con(con)
+        if len(results) > 0:
+            return results[0]
+        else:
+            return (None, None)
+
+    def verify_password(self, user_dn, password):
+        con = self._get_ldap_con()
+        valid = True
+        try:
+            con.simple_bind_s(user_dn, password)
+        except ldap.INVALID_CREDENTIALS:
+            valid = False
+        self._close_ldap_con(con)
+        return valid

--- a/flask_security/ldap/forms.py
+++ b/flask_security/ldap/forms.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+"""
+    flask_security.ldap.forms
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Flask-Security ldap forms module
+
+    :copyright: (c) 2012 by Matt Wright.
+    :license: MIT, see LICENSE for more details.
+"""
+
+import six
+
+from werkzeug.local import LocalProxy
+
+from flask import request, current_app
+from flask_security.utils import encrypt_password
+from wtforms import StringField, PasswordField, SubmitField, BooleanField
+
+from ..forms import Form, NextFormMixin, get_form_field_label
+from ..utils import config_value, get_message
+from ..signals import ldap_user_login, ldap_user_registred
+
+_datastore = LocalProxy(lambda: current_app.extensions['security'].datastore)
+
+
+class LDAPLoginForm(Form, NextFormMixin):
+    email = StringField('User ID')
+    password = PasswordField(get_form_field_label('password'))
+    remember = BooleanField(get_form_field_label('remember_me'))
+    submit = SubmitField(get_form_field_label('login'))
+
+    def __init__(self, *args, **kwargs):
+        super(LDAPLoginForm, self).__init__(*args, **kwargs)
+        if not self.next.data:
+            self.next.data = request.args.get('next', '')
+        self.remember.default = config_value('DEFAULT_REMEMBER_ME')
+
+    def validate(self):
+        if not super(LDAPLoginForm, self).validate():
+            return False
+
+        if self.email.data.strip() == '':
+            self.email.errors.append(get_message('USERID_NOT_PROVIDED')[0])
+            return False
+
+        if self.password.data.strip() == '':
+            self.password.errors.append(
+                get_message('PASSWORD_NOT_PROVIDED')[0]
+            )
+            return False
+
+        user_dn, ldap_data = _datastore.query_ldap_user(self.email.data)
+
+        if user_dn is None:
+            self.email.errors.append(get_message('USER_DOES_NOT_EXIST')[0])
+            return False
+
+        if not _datastore.verify_password(user_dn, self.password.data):
+            self.password.errors.append(get_message('INVALID_PASSWORD')[0])
+            return False
+
+        ldap_email = ldap_data.get(
+            six.u(config_value('LDAP_EMAIL_FIELDNAME')), ''
+        )
+        ldap_email = ldap_email[0].decode('utf-8')
+        password = encrypt_password(self.password.data)
+
+        if _datastore.find_user(email=ldap_email):
+            self.user = _datastore.get_user(ldap_email)
+            self.user.password = password
+            ldap_user_login.send(current_app._get_current_object(),
+                                 datastore=_datastore,
+                                 user=self.user, ldap_data=ldap_data)
+        else:
+            self.user = _datastore.create_user(
+                email=ldap_email, password=password,
+            )
+            ldap_user_registred.send(current_app._get_current_object(),
+                                     datastore=_datastore, user=self.user,
+                                     ldap_data=ldap_data)
+        return True

--- a/flask_security/signals.py
+++ b/flask_security/signals.py
@@ -26,3 +26,7 @@ password_reset = signals.signal("password-reset")
 password_changed = signals.signal("password-changed")
 
 reset_password_instructions_sent = signals.signal("password-reset-instructions-sent")
+
+ldap_user_registred = signals.signal('ldap-user-registred')
+
+ldap_user_login = signals.signal('ldap-user-login')


### PR DESCRIPTION
This Pull request adds a basic LDAP Authentication implementation using the `pyldap` library. In order to address the Issue #420, it extends the already implemented `SQLAlchemyUserDatastore` and adds a new form (`LDAPLoginForm`). Also, adds two more signals (`ldap-user-registred` and `ldap-user-login`), allowing the app to customize and fetch other LDAP attributes.

Since this feature might not be useful for some users all LDAP features are isolated in a submodule. With this approach, installing the `pyldap` module isn't a prerequisite for flask-security:

```
from flask_security.ldap import LDAPUserDatastore, LDAPLoginForm

user_datastore = LDAPUserDatastore(db, User, Role)
security = Security(app, user_datastore, {'login_form': LDAPLoginForm})
```

I'd appreciate very much if someone could review this, since I'm kinda new in the flask world and it's the first time I'm using flask-security.

Thanks!
