### PR TITLE
Use ProxyFix instead of inspecting X-Forwarded-For header

### DIFF
--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -62,11 +62,7 @@ def login_user(user, remember=None):
         return False
 
     if _security.trackable:
-        if 'X-Forwarded-For' in request.headers:
-            remote_addr = request.headers.getlist(
-                "X-Forwarded-For")[0].rpartition(' ')[-1]
-        else:
-            remote_addr = request.remote_addr or 'untrackable'
+        remote_addr = request.remote_addr or 'untrackable'
 
         old_current_login, new_current_login = user.current_login_at, datetime.utcnow()
         old_current_ip, new_current_ip = user.current_login_ip, remote_addr

--- a/tests/test_trackable.py
+++ b/tests/test_trackable.py
@@ -9,11 +9,13 @@
 import pytest
 
 from utils import authenticate, logout
+from werkzeug.contrib.fixers import ProxyFix
 
 pytestmark = pytest.mark.trackable()
 
 
 def test_trackable_flag(app, client):
+    app.wsgi_app = ProxyFix(app.wsgi_app, num_proxies=1)
     e = 'matt@lp.com'
     authenticate(client, email=e)
     logout(client)
@@ -29,11 +31,13 @@ def test_trackable_flag(app, client):
 
 
 def test_trackable_with_multiple_ips_in_headers(app, client):
+    app.wsgi_app = ProxyFix(app.wsgi_app, num_proxies=2)
+
     e = 'matt@lp.com'
     authenticate(client, email=e)
     logout(client)
     authenticate(client, email=e, headers={
-        'X-Forwarded-For': '99.99.99.99, 88.88.88.88'})
+        'X-Forwarded-For': '99.99.99.99, 88.88.88.88, 77.77.77.77'})
 
     with app.app_context():
         user = app.security.datastore.find_user(email=e)


### PR DESCRIPTION
PR #352 fixed a security issue in extracting a correct remote IP address from `X-Forwarded-For` header. 

The fix however doesn't take multiple trusted proxies into account, which you typically have in a load balanced setup (e.g. HAProxy + Nginx). The problem is located [here](https://github.com/mattupstate/flask-security/blob/develop/flask_security/utils.py#L65-L66), and can quickly be demonstrated with this example where it's always the last address in `X-Forwarded-For` being chosen:

``` python
>>> x_forwarded_for = '33.33.33.33, 22.22.22.22, 11.11.11.11'
>>> x_forwarded_for.rpartition(' ')[-1]
'11.11.11.11'
```

The problem with the current code is that if you use [ProxyFix](http://werkzeug.pocoo.org/docs/0.11/contrib/fixers/#werkzeug.contrib.fixers.ProxyFix) to set a correct IP address in `request.remote_addr`, then Flask-Security doesn't pick it up because X-Forwarded-For headers are inspected first. The workaround so far, is in addition to ProxyFix to use [HeaderRewriterFix](http://werkzeug.pocoo.org/docs/0.11/contrib/fixers/#werkzeug.contrib.fixers.HeaderRewriterFix) to remove the X-Forwarded-For headers completely from the request.
### Proposal

IMHO, Flask-Security (and any other Flask extension for that matter) should rely solely on `request.remote_addr` to get the client IP address, and only document that you should use ProxyFix in order to ensure that `remote_addr` is set correctly ([already done in Flask-Security](https://pythonhosted.org/Flask-Security/configuration.html#feature-flags)).
