### PR TITLE
Include LICENSE in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include LICENSE
 include README.rst
 include requirements.txt
 include requirements-dev.txt


### PR DESCRIPTION
For the [conda-forge build](https://github.com/conda-forge/staged-recipes/pull/1515), we'd like to include a hard-link to the `LICENSE`. Doing this requires having an explicit reference to `LICENSE` in the manifest so it can be bundled with the source.