### PR TITLE
Bump Flask-WTF to 0.13

### DIFF
--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -12,7 +12,7 @@
 import inspect
 
 from flask import request, current_app, flash
-from flask_wtf import Form as BaseForm
+from flask_wtf import FlaskForm as BaseForm
 from wtforms import StringField, PasswordField, validators, \
     SubmitField, HiddenField, BooleanField, ValidationError, Field
 from flask_login import current_user

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ Flask>=0.9
 Flask-Login>=0.3.0,<0.4
 Flask-Mail>=0.7.3
 Flask-Principal>=0.3.3
-Flask-WTF>=0.8
+Flask-WTF>=0.13
 itsdangerous>=0.17
 passlib>=1.6.4


### PR DESCRIPTION
We just began seeing all these warnings in our project:

```
/Users/jacquerie/.virtualenvs/inspire/lib/python2.7/site-packages/flask_security/forms.py:89: FlaskWTFDeprecationWarning: "flask_wtf.Form" has been renamed to "FlaskForm" and will be removed in 1.0.
  class Form(BaseForm):
/Users/jacquerie/.virtualenvs/inspire/lib/python2.7/site-packages/flask_security/forms.py:154: FlaskWTFDeprecationWarning: "flask_wtf.Form" has been renamed to "FlaskForm" and will be removed in 1.0.
  class SendConfirmationForm(Form, UserEmailFormMixin):
/Users/jacquerie/.virtualenvs/inspire/lib/python2.7/site-packages/flask_security/forms.py:173: FlaskWTFDeprecationWarning: "flask_wtf.Form" has been renamed to "FlaskForm" and will be removed in 1.0.
  class ForgotPasswordForm(Form, UserEmailFormMixin):
/Users/jacquerie/.virtualenvs/inspire/lib/python2.7/site-packages/flask_security/forms.py:187: FlaskWTFDeprecationWarning: "flask_wtf.Form" has been renamed to "FlaskForm" and will be removed in 1.0.
  class PasswordlessLoginForm(Form, UserEmailFormMixin):
/Users/jacquerie/.virtualenvs/inspire/lib/python2.7/site-packages/flask_security/forms.py:204: FlaskWTFDeprecationWarning: "flask_wtf.Form" has been renamed to "FlaskForm" and will be removed in 1.0.
  class LoginForm(Form, NextFormMixin):
/Users/jacquerie/.virtualenvs/inspire/lib/python2.7/site-packages/flask_security/forms.py:251: FlaskWTFDeprecationWarning: "flask_wtf.Form" has been renamed to "FlaskForm" and will be removed in 1.0.
  UniqueEmailFormMixin, NewPasswordFormMixin):
/Users/jacquerie/.virtualenvs/inspire/lib/python2.7/site-packages/flask_security/forms.py:256: FlaskWTFDeprecationWarning: "flask_wtf.Form" has been renamed to "FlaskForm" and will be removed in 1.0.
  NextFormMixin):
/Users/jacquerie/.virtualenvs/inspire/lib/python2.7/site-packages/flask_security/forms.py:263: FlaskWTFDeprecationWarning: "flask_wtf.Form" has been renamed to "FlaskForm" and will be removed in 1.0.
  class ResetPasswordForm(Form, NewPasswordFormMixin, PasswordConfirmFormMixin):
/Users/jacquerie/.virtualenvs/inspire/lib/python2.7/site-packages/flask_security/forms.py:269: FlaskWTFDeprecationWarning: "flask_wtf.Form" has been renamed to "FlaskForm" and will be removed in 1.0.
  class ChangePasswordForm(Form, PasswordFormMixin):
```

This PR bumps `Flask-WTF` to 0.13 and updates the API correspondingly to suppress them.
