### PR TITLE
replace token loader with request loader to fix #81

### DIFF
--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -58,15 +58,7 @@ def _get_unauthorized_view():
 
 
 def _check_token():
-    header_key = _security.token_authentication_header
-    args_key = _security.token_authentication_key
-    header_token = request.headers.get(header_key, None)
-    token = request.args.get(args_key, header_token)
-    if request.get_json(silent=True):
-        if not isinstance(request.json, list):
-            token = request.json.get(args_key, token)
-
-    user = _security.login_manager.token_callback(token)
+    user = _security.login_manager.request_callback(request)
 
     if user and user.is_authenticated:
         app = current_app._get_current_object()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask>=0.9
-Flask-Login>=0.3.0,<0.4
+Flask-Login>=0.3.0
 Flask-Mail>=0.7.3
 Flask-Principal>=0.3.3
 Flask-WTF>=0.8

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -271,7 +271,7 @@ def test_remember_token(client):
     assert b'profile' in response.data
 
 
-def test_token_loader_does_not_fail_with_invalid_token(client):
+def test_request_loader_does_not_fail_with_invalid_token(client):
     c = Cookie(version=0, name='remember_token', value='None', port=None,
                port_specified=False, domain='www.example.com',
                domain_specified=False, domain_initial_dot=False, path='/',


### PR DESCRIPTION
Just moved some code around, but the main change is using `request_loader` on the login manager instead of `token_loader` to fix #557.
