### PR TITLE
security fix for changed email confirmation

### DIFF
--- a/flask_security/confirmable.py
+++ b/flask_security/confirmable.py
@@ -71,7 +71,12 @@ def confirm_email_token_status(token):
 
     :param token: The confirmation token
     """
-    return get_token_status(token, 'confirm', 'CONFIRM_EMAIL')
+    expired, invalid, user, token_data = \
+        get_token_status(token, 'confirm', 'CONFIRM_EMAIL', return_data=True)
+    if not invalid and user:
+        user_id, token_email_md5 = token_data
+        invalid = md5(user.email) != token_email_md5
+    return expired, invalid, user
 
 
 def confirm_user(user):

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -124,6 +124,26 @@ def test_expired_confirmation_token(client, get_message):
 
 
 @pytest.mark.registerable()
+def test_email_conflict_for_confirmation_token(app, client, get_message, sqlalchemy_datastore):
+    with capture_registrations() as registrations:
+        data = dict(email='mary@lp.com', password='password', next='')
+        client.post('/register', data=data, follow_redirects=True)
+
+    user = registrations[0]['user']
+    token = registrations[0]['confirm_token']
+
+    # Change the user's email
+    user.email = 'tom@lp.com'
+    with app.app_context():
+        sqlalchemy_datastore.put(user)
+        sqlalchemy_datastore.commit()
+
+    response = client.get('/confirm/' + token, follow_redirects=True)
+    msg = get_message('INVALID_CONFIRMATION_TOKEN')
+    assert msg in response.data
+
+
+@pytest.mark.registerable()
 @pytest.mark.settings(login_without_confirmation=True)
 def test_login_when_unconfirmed(client, get_message):
     data = dict(email='mary@lp.com', password='password', next='')


### PR DESCRIPTION
When validating a confirmation token, also checks if the email that
the token was created with matches the user's current email.