### PR TITLE
Add notes to documentation for login_user. Closes #566.

### DIFF
--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -49,7 +49,8 @@ else:  # pragma: no cover
 
 
 def login_user(user, remember=None):
-    """Performs the login routine.
+    """Performs the login routine. If SECURITY_TRACKABLE is used, make sure you commit
+    changes after this request (i.e. ``app.security.datastore.commit()``).
 
     :param user: The user to login
     :param remember: Flag specifying if the remember cookie should be set. Defaults to ``False``

--- a/tests/test_trackable.py
+++ b/tests/test_trackable.py
@@ -9,6 +9,8 @@
 import pytest
 
 from utils import authenticate, logout
+from flask import redirect, after_this_request
+from flask_security import login_user
 
 pytestmark = pytest.mark.trackable()
 
@@ -41,4 +43,39 @@ def test_trackable_with_multiple_ips_in_headers(app, client):
         assert user.current_login_at is not None
         assert user.last_login_ip == 'untrackable'
         assert user.current_login_ip == '88.88.88.88'
+        assert user.login_count == 2
+
+
+def test_trackable_using_login_user(app, client):
+    """
+    This tests is only to serve as an example of how one needs to call
+    datastore.commit() after logging a user in to make sure the trackable
+    fields are saved to the datastore.
+    """
+
+    @app.route('/login_custom', methods=['POST'])
+    def login_custom():
+        user = app.security.datastore.find_user(email=e)
+        login_user(user)
+
+        @after_this_request
+        def save_user(response):
+            app.security.datastore.commit()
+            return response
+
+        return redirect('/')
+
+    e = 'matt@lp.com'
+    authenticate(client, email=e)
+    logout(client)
+
+    data = dict(email=e, password="password", remember='y')
+    client.post('/login_custom', data=data, headers={'X-Forwarded-For': '127.0.0.1'})
+
+    with app.app_context():
+        user = app.security.datastore.find_user(email=e)
+        assert user.last_login_at is not None
+        assert user.current_login_at is not None
+        assert user.last_login_ip == 'untrackable'
+        assert user.current_login_ip == '127.0.0.1'
         assert user.login_count == 2


### PR DESCRIPTION
When `SECURITY_TRACKABLE` is enabled, one must commit the transaction after the request in which `login_user` is called. This is used throughout `flask_security` and was learned from reading the code.

This also adds a test which shows how this works.