### PR TITLE
add pymodm support for flask-security

### DIFF
--- a/flask_security/datastore_pymodm.py
+++ b/flask_security/datastore_pymodm.py
@@ -1,0 +1,63 @@
+from flask_security.datastore import *
+
+
+class PymodmDatastore(Datastore):
+    '''
+    Inheritance the datastore.
+    '''
+    def __init__(self):
+        pass
+    def put(self, model):
+        model.save( full_clean=False)
+        # model.save()
+        return model
+
+    def delete(self, model):
+        model.delete()
+
+
+class PymodmUserDatastore(PymodmDatastore, UserDatastore):
+    '''
+    Use this to support the pymodm.
+
+    '''
+
+
+    def __init__(self,  user_model, role_model):
+        PymodmDatastore.__init__(self)
+        UserDatastore.__init__(self, user_model, role_model)
+
+    def get_user(self, identifier):
+
+        from pymodm.errors import ValidationError
+        try:
+            return self.user_model.objects.raw({'id':identifier}).first()
+        except ValidationError:
+            pass
+
+        # for attr in get_identity_attributes():
+        #     query_key = '%s__iexact' % attr
+        #     query = {query_key: identifier}
+        #     rv = self.user_model.objects(**query).first()
+        #     if rv is not None:
+        #         return rv
+
+    def find_user(self, **kwargs):
+
+        from pymodm.errors import ValidationError
+
+        try:
+            for k, v in kwargs:
+                return self.user_model.objects.raw({k:v}).first()
+
+        except ValidationError:  # pragma: no cover
+            return None
+
+    def find_role(self, role):
+
+        try:
+            return self.role_model.objects.raw({'name' : role}).first()
+        except self.role_model.DoesNotExist:
+            return None
+
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ Flask-SQLAlchemy>=1.0
 bcrypt>=1.0.2
 flask-mongoengine>=0.7.0,<0.7.3
 flask-peewee>=0.6.5
+pymodm
 pymongo==2.8
 pytest>=2.5.2
 pytest-cov>=1.6


### PR DESCRIPTION
Pymodm is a an ODM tool developed by mongodb. It is still in developing.

I add 2 classes `PymodmUserDatastore` `PymodmDatastore` to make flask-security run on pymodm.

It still need to be tested more. But I think this is a good start.