### PR TITLE
Configurable timezone aware datetimes

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -271,6 +271,9 @@ Miscellaneous
 ``SECURITY_DEFAULT_REMEMBER_ME``              Specifies the default "remember
                                               me" value used when logging in
                                               a user. Defaults to ``False``.
+``SECURITY_DATETIME_FACTORY``                 Specifies the default datetime
+                                              factory. Defaults to
+                                              ``datetime.datetime.utcnow``.
 ============================================= ==================================
 
 Messages

--- a/flask_security/confirmable.py
+++ b/flask_security/confirmable.py
@@ -6,10 +6,9 @@
     Flask-Security confirmable module
 
     :copyright: (c) 2012 by Matt Wright.
+    :copyright: (c) 2017 by CERN.
     :license: MIT, see LICENSE for more details.
 """
-
-from datetime import datetime
 
 from flask import current_app as app
 from werkzeug.local import LocalProxy
@@ -81,7 +80,7 @@ def confirm_user(user):
     """
     if user.confirmed_at is not None:
         return False
-    user.confirmed_at = datetime.utcnow()
+    user.confirmed_at = _security.datetime_factory()
     _datastore.put(user)
     user_confirmed.send(app._get_current_object(), user=user)
     return True

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -6,8 +6,11 @@
     Flask-Security core module
 
     :copyright: (c) 2012 by Matt Wright.
+    :copyright: (c) 2017 by CERN.
     :license: MIT, see LICENSE for more details.
 """
+
+from datetime import datetime
 
 from flask import current_app, render_template
 from flask_login import AnonymousUserMixin, UserMixin as BaseUserMixin, \
@@ -20,7 +23,8 @@ from werkzeug.datastructures import ImmutableList
 from werkzeug.local import LocalProxy
 from werkzeug.security import safe_str_cmp
 
-from .utils import config_value as cv, get_config, md5, url_for_security, string_types
+from .utils import config_value as cv, get_config, md5, url_for_security, \
+    string_types
 from .views import create_blueprint
 from .forms import LoginForm, ConfirmRegisterForm, RegisterForm, \
     ForgotPasswordForm, ChangePasswordForm, ResetPasswordForm, \
@@ -100,7 +104,8 @@ _default_config = {
         # And always last one...
         'plaintext'
     ],
-    'DEPRECATED_PASSWORD_SCHEMES': ['auto']
+    'DEPRECATED_PASSWORD_SCHEMES': ['auto'],
+    'DATETIME_FACTORY': datetime.utcnow,
 }
 
 #: Default Flask-Security messages

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -20,7 +20,7 @@ except ImportError:  # pragma: no cover
     from urllib.parse import urlsplit
 
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from flask import url_for, flash, current_app, request, session, render_template
 from flask_login import login_user as _login_user, logout_user as _logout_user
@@ -67,7 +67,7 @@ def login_user(user, remember=None):
         else:
             remote_addr = request.remote_addr or 'untrackable'
 
-        old_current_login, new_current_login = user.current_login_at, datetime.utcnow()
+        old_current_login, new_current_login = user.current_login_at, _security.datetime_factory()
         old_current_ip, new_current_ip = user.current_login_ip, remote_addr
 
         user.last_login_at = old_current_login or new_current_login

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,9 @@
     ~~~~~~~~
 
     Test fixtures and what not
+
+    :copyright: (c) 2017 by CERN.
+    :license: MIT, see LICENSE for more details.
 """
 
 import os


### PR DESCRIPTION
Added new configuration option `SECURITY_TIMEZONE_AWARENESS` which can
be used to force default timezone.

(closes mattupstate/flask-security#466)

(cc @philsalesses)