### PR TITLE
Default SECURITY_EMAIL_SENDER respects MAIL_DEFAULT_SENDER in Flask-Mail

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -425,10 +425,11 @@ class Security(object):
         """
         datastore = datastore or self.datastore
 
-        email_sender = app.config.get('MAIL_DEFAULT_SENDER')
-        _default_config['EMAIL_SENDER'] = email_sender or 'no-reply@localhost'
-
         for key, value in _default_config.items():
+            if key == 'EMAIL_SENDER' and app.config.get('MAIL_DEFAULT_SENDER'):
+                app.config.setdefault(
+                    'SECURITY_' + key, app.config.get('MAIL_DEFAULT_SENDER')
+                )
             app.config.setdefault('SECURITY_' + key, value)
 
         for key, value in _default_messages.items():

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -425,6 +425,9 @@ class Security(object):
         """
         datastore = datastore or self.datastore
 
+        email_sender = app.config.get('MAIL_DEFAULT_SENDER')
+        _default_config['EMAIL_SENDER'] = email_sender or 'no-reply@localhost'
+
         for key, value in _default_config.items():
             app.config.setdefault('SECURITY_' + key, value)
 


### PR DESCRIPTION
Since email is sent using Flask-Mail, when ```SECURITY_EMAIL_SENDER``` is not set for Flask-Security, it will be nice to search for ```MAIL_DEFAULT_SENDER``` setting, which sets default email sender in Flask-Mail, instead of using ```no-reply@localhost```.

In this case, users don't need to set same default sender as ```SECURITY_EMAIL_SENDER``` and ```MAIL_DEFAULT_SENDER``` for Flask-Security and Flask-Mail, respectively. On the other hand, users can explicitly set ```SECURITY_EMAIL_SENDER``` for Flask-Security and this setting will overide default sender in Flask-mail no matter it exists or not.