### PR TITLE
Add validators to default LoginForm

### DIFF
--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -205,8 +205,9 @@ class PasswordlessLoginForm(Form, UserEmailFormMixin):
 class LoginForm(Form, NextFormMixin):
     """The default login form"""
 
-    email = StringField(get_form_field_label('email'))
-    password = PasswordField(get_form_field_label('password'))
+    email = StringField(get_form_field_label('email'), validators=[Required()])
+    password = PasswordField(get_form_field_label('password'),
+                             validators=[password_required])
     remember = BooleanField(get_form_field_label('remember_me'))
     submit = SubmitField(get_form_field_label('login'))
 

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -127,7 +127,8 @@ class NewPasswordFormMixin():
 class PasswordConfirmFormMixin():
     password_confirm = PasswordField(
         get_form_field_label('retype_password'),
-        validators=[EqualTo('password', message='RETYPE_PASSWORD_MISMATCH')])
+        validators=[password_required,
+                    EqualTo('password', message='RETYPE_PASSWORD_MISMATCH')])
 
 
 class NextFormMixin():
@@ -285,8 +286,8 @@ class ChangePasswordForm(Form, PasswordFormMixin):
 
     new_password_confirm = PasswordField(
         get_form_field_label('retype_password'),
-        validators=[EqualTo('new_password',
-                            message='RETYPE_PASSWORD_MISMATCH')])
+        validators=[password_required,
+                    EqualTo('new_password', message='RETYPE_PASSWORD_MISMATCH')])
 
     submit = SubmitField(get_form_field_label('change_password'))
 

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -127,8 +127,8 @@ class NewPasswordFormMixin():
 class PasswordConfirmFormMixin():
     password_confirm = PasswordField(
         get_form_field_label('retype_password'),
-        validators=[password_required,
-                    EqualTo('password', message='RETYPE_PASSWORD_MISMATCH')])
+        validators=[EqualTo('password', message='RETYPE_PASSWORD_MISMATCH'),
+                    password_required])
 
 
 class NextFormMixin():
@@ -206,7 +206,8 @@ class PasswordlessLoginForm(Form, UserEmailFormMixin):
 class LoginForm(Form, NextFormMixin):
     """The default login form"""
 
-    email = StringField(get_form_field_label('email'), validators=[Required()])
+    email = StringField(get_form_field_label('email'),
+                        validators=[Required(message='EMAIL_NOT_PROVIDED')])
     password = PasswordField(get_form_field_label('password'),
                              validators=[password_required])
     remember = BooleanField(get_form_field_label('remember_me'))
@@ -227,15 +228,6 @@ class LoginForm(Form, NextFormMixin):
 
     def validate(self):
         if not super(LoginForm, self).validate():
-            return False
-
-        if not self.email.data or self.email.data.strip() == '':
-            self.email.errors.append(get_message('EMAIL_NOT_PROVIDED')[0])
-            return False
-
-        if not self.password.data or self.password.data.strip() == '':
-            self.password.errors.append(
-                get_message('PASSWORD_NOT_PROVIDED')[0])
             return False
 
         self.user = _datastore.get_user(self.email.data)
@@ -286,8 +278,9 @@ class ChangePasswordForm(Form, PasswordFormMixin):
 
     new_password_confirm = PasswordField(
         get_form_field_label('retype_password'),
-        validators=[password_required,
-                    EqualTo('new_password', message='RETYPE_PASSWORD_MISMATCH')])
+        validators=[EqualTo('new_password',
+                            message='RETYPE_PASSWORD_MISMATCH'),
+                    password_required])
 
     submit = SubmitField(get_form_field_label('change_password'))
 


### PR DESCRIPTION
Data required validators are added to several fields since these fields are always essencial. Then invalid requests with empty fields won't hit server side and website users should have better experiences.

- Data required valildators are added to ```email``` and ```password``` fields of ```LoginForm``` since they are always needed for login.

-  Data required valildators are added to ```new_password_confirm``` and ```password_confirm``` in ```ChangePasswordForm``` and ```PasswordConfirmFormMixin``` respectively since reconfirmed password are also always neccessary.