### PR TITLE
Set anonymous required for send_confirmation

### DIFF
--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -183,6 +183,7 @@ def token_login(token):
     return redirect(get_post_login_redirect())
 
 
+@anonymous_user_required
 def send_confirmation():
     """View function which sends confirmation instructions."""
 


### PR DESCRIPTION
If a user has already signed in, it means the email has already been confirmed if confirmable is true and there is no point in allowing website users to access resending confimation page anymore. So this ```send_confirmation``` function which provides ```/confirm``` view should be anonymous required.

If this setting is not set by design for some purpuses, I will keep this PR here.