### PR TITLE
Custom User Payload Handler

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -57,7 +57,7 @@ If you want a custom payload after Register or Login an user, define
 the method get_security_payload in your User model. The method must return a
 serializable object:
 
-::
+.. code-block:: python
 
     class User(db.Model, UserMixin):
         id = db.Column(db.Integer, primary_key=True)

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -58,16 +58,19 @@ the method get_security_payload in your User model. The method must return a
 serializable object:
 
 ::
-    UserModel(Base, UserMixin):
+
+    class User(db.Model, UserMixin):
         id = db.Column(db.Integer, primary_key=True)
-        email = db.Column(db.String(120), unique=True, nullable=False)
-        password = db.Column(db.String(255))
+        email = TextField()
+        password = TextField()
+        active = BooleanField(default=True)
+        confirmed_at = DateTimeField(null=True)
         name = db.Column(db.String(80))
-        ....
-        
+
+        # Custom User Payload
         def get_security_payload(self):
             return {
-                id: self.id,
-                name: self.name,
-                email: self.email  
+                'id': self.id,
+                'name': self.name,
+                'email': self.email
             }

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -49,3 +49,25 @@ additional fields:
 * ``last_login_ip``
 * ``current_login_ip``
 * ``login_count``
+
+Custom User Payload
+^^^^^^^^^^^^^^^^^^^
+
+If you want a custom payload after Register or Login an user, define
+the method get_security_payload in your User model. The method must return a
+serializable object:
+
+::
+    UserModel(Base, UserMixin):
+        id = db.Column(db.Integer, primary_key=True)
+        email = db.Column(db.String(120), unique=True, nullable=False)
+        password = db.Column(db.String(255))
+        name = db.Column(db.String(80))
+        ....
+        
+        def get_security_payload(self):
+            return {
+                id: self.id,
+                name: self.name,
+                email: self.email  
+            }

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -51,6 +51,7 @@ _default_config = {
     'PASSWORD_SALT': None,
     'PASSWORD_SINGLE_HASH': False,
     'LOGIN_URL': '/login',
+    'CUSTOM_USER_PAYLOAD': False,
     'LOGOUT_URL': '/logout',
     'REGISTER_URL': '/register',
     'RESET_URL': '/reset',

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -51,7 +51,6 @@ _default_config = {
     'PASSWORD_SALT': None,
     'PASSWORD_SINGLE_HASH': False,
     'LOGIN_URL': '/login',
-    'CUSTOM_USER_PAYLOAD': False,
     'LOGOUT_URL': '/logout',
     'REGISTER_URL': '/register',
     'RESET_URL': '/reset',
@@ -385,6 +384,10 @@ class UserMixin(BaseUserMixin):
             return role in (role.name for role in self.roles)
         else:
             return role in self.roles
+
+    def get_security_payload(self):
+        """Serialize user object as response payload."""
+        return {'id': str(self.id)}
 
 
 class AnonymousUser(AnonymousUserMixin):

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -45,9 +45,8 @@ def _render_json(form, include_user=True, include_auth_token=False):
         code = 200
         response = dict()
         if include_user:
-            response['user'] = dict(id=str(form.user.id))
-            if _security.custom_user_payload:
-                response['user'] = form.user.payload_handler()
+            response['user'] = form.user.get_security_payload()
+
         if include_auth_token:
             token = form.user.get_auth_token()
             response['user']['authentication_token'] = token

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -46,6 +46,8 @@ def _render_json(form, include_user=True, include_auth_token=False):
         response = dict()
         if include_user:
             response['user'] = dict(id=str(form.user.id))
+            if _security.custom_user_payload:
+                response['user'] = form.user.payload_handler()
         if include_auth_token:
             token = form.user.get_auth_token()
             response['user']['authentication_token'] = token


### PR DESCRIPTION
Sometimes after Create or Login an user (base on Token) we need some information about he/she, so after receive the token we need to request again the server.

Example: 
When we send the email and password Flask-Security returns:

```python
{
    "meta": {
        "code": 200
    },
    "response": {
        "user": {
            "authentication_token": "WyI5OTk5OTk5IiwiMTE0ODZlNzU3MGNjNWRkMjFiZDhkMzI4M2I5ZTUxZjYiXQ.C39mEg.UGm6QqOaGlZ3wJsu5jQuWaIIA8M",
            "id": "9999999"
        }
    }
}
```

Is really good. But if we need more information we should request the server again.

I introduced a new setting flag called SECURITY_CUSTOM_USER_PAYLOAD. By default is False.
If you set to True, you must define a function in your User Model called 'payload_handler' that must return a serializable object:

```python
UserModel(Base, UserMixin):
    id = db.Column(db.Integer, primary_key=True)
    email = db.Column(db.String(120), unique=True, nullable=False)
    password = db.Column(db.String(255))
    name = db.Column(db.String(80))
    ....
    
    def payload_handler(self):
        return {
            id: self.id,
            name: self.name,
            email: self.email  
        }
```

Now after login the user the response is:

```python
{
    "meta": {
        "code": 200
    },
    "response": {
        "user": {
            "authentication_token": "WyI5OTk5OTk5IiwiMTE0ODZlNzU3MGNjNWRkMjFiZDhkMzI4M2I5ZTUxZjYiXQ.C39maw.EYNyKu2-T70BJFyWlFiMsjWh-XA",
            "email": "test@tes.com",
            "id": 9999999,
            "name": "test",
        }
    }
}
```

