### PR TITLE
prevent convert a number string of identity attribute to number and p…

### DIFF
--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -184,8 +184,8 @@ class SQLAlchemyUserDatastore(SQLAlchemyDatastore, UserDatastore):
         UserDatastore.__init__(self, user_model, role_model)
 
     def get_user(self, identifier):
-        if self._is_numeric(identifier):
-            return self.user_model.query.get(identifier)
+        # if self._is_numeric(identifier):
+        #     return self.user_model.query.get(identifier)
         for attr in get_identity_attributes():
             query = getattr(self.user_model, attr).ilike(identifier)
             rv = self.user_model.query.filter(query).first()


### PR DESCRIPTION
Prevent convert a number string of identity attribute to number and prevent get user by primary id. For example, use phone of user as the identity attribute. #604 