### PR TITLE
Replace md5 hashing with sha512

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,3 +37,4 @@ Srijan Choudhary
 Tristan Escalada
 Vadim Kotov
 Walt Askew
+John Paraskevopoulos

--- a/flask_security/confirmable.py
+++ b/flask_security/confirmable.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from flask import current_app as app
 from werkzeug.local import LocalProxy
 
-from .utils import send_mail, md5, url_for_security, get_token_status,\
+from .utils import send_mail, sha512, url_for_security, get_token_status,\
     config_value
 from .signals import user_confirmed, confirm_instructions_sent
 
@@ -52,7 +52,7 @@ def generate_confirmation_token(user):
 
     :param user: The user to work with
     """
-    data = [str(user.id), md5(user.email)]
+    data = [str(user.id), sha512(user.email)]
     return _security.confirm_serializer.dumps(data)
 
 

--- a/flask_security/confirmable.py
+++ b/flask_security/confirmable.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from flask import current_app as app
 from werkzeug.local import LocalProxy
 
-from .utils import send_mail, sha512, url_for_security, get_token_status,\
+from .utils import send_mail, hash_data, url_for_security, get_token_status,\
     config_value
 from .signals import user_confirmed, confirm_instructions_sent
 
@@ -52,7 +52,7 @@ def generate_confirmation_token(user):
 
     :param user: The user to work with
     """
-    data = [str(user.id), sha512(user.email)]
+    data = [str(user.id), hash_data(user.email)]
     return _security.confirm_serializer.dumps(data)
 
 

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -18,9 +18,7 @@ from itsdangerous import URLSafeTimedSerializer
 from passlib.context import CryptContext
 from werkzeug.datastructures import ImmutableList
 from werkzeug.local import LocalProxy
-from werkzeug.security import safe_str_cmp
-
-from .utils import config_value as cv, get_config, sha512, url_for_security, string_types
+from .utils import config_value as cv, get_config, hash_data, verify_hash, url_for_security, string_types
 from .views import create_blueprint
 from .forms import LoginForm, ConfirmRegisterForm, RegisterForm, \
     ForgotPasswordForm, ChangePasswordForm, ResetPasswordForm, \
@@ -198,7 +196,7 @@ def _token_loader(token):
         data = _security.remember_token_serializer.loads(
             token, max_age=_security.token_max_age)
         user = _security.datastore.find_user(id=data[0])
-        if user and safe_str_cmp(sha512(user.password), data[1]):
+        if user and (verify_hash(data[1], user.password)):
             return user
     except:
         pass
@@ -319,7 +317,7 @@ class UserMixin(BaseUserMixin):
 
     def get_auth_token(self):
         """Returns the user's authentication token."""
-        data = [str(self.id), sha512(self.password)]
+        data = [str(self.id), hash_data(self.password)]
         return _security.remember_token_serializer.dumps(data)
 
     def has_role(self, role):

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -196,7 +196,7 @@ def _token_loader(token):
         data = _security.remember_token_serializer.loads(
             token, max_age=_security.token_max_age)
         user = _security.datastore.find_user(id=data[0])
-        if user and (verify_hash(data[1], user.password)):
+        if user and verify_hash(data[1], user.password):
             return user
     except:
         pass

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -20,7 +20,7 @@ from werkzeug.datastructures import ImmutableList
 from werkzeug.local import LocalProxy
 from werkzeug.security import safe_str_cmp
 
-from .utils import config_value as cv, get_config, md5, url_for_security, string_types
+from .utils import config_value as cv, get_config, sha512, url_for_security, string_types
 from .views import create_blueprint
 from .forms import LoginForm, ConfirmRegisterForm, RegisterForm, \
     ForgotPasswordForm, ChangePasswordForm, ResetPasswordForm, \
@@ -198,7 +198,7 @@ def _token_loader(token):
         data = _security.remember_token_serializer.loads(
             token, max_age=_security.token_max_age)
         user = _security.datastore.find_user(id=data[0])
-        if user and safe_str_cmp(md5(user.password), data[1]):
+        if user and safe_str_cmp(sha512(user.password), data[1]):
             return user
     except:
         pass
@@ -319,7 +319,7 @@ class UserMixin(BaseUserMixin):
 
     def get_auth_token(self):
         """Returns the user's authentication token."""
-        data = [str(self.id), md5(self.password)]
+        data = [str(self.id), sha512(self.password)]
         return _security.remember_token_serializer.dumps(data)
 
     def has_role(self, role):

--- a/flask_security/recoverable.py
+++ b/flask_security/recoverable.py
@@ -14,7 +14,7 @@ from werkzeug.local import LocalProxy
 from werkzeug.security import safe_str_cmp
 
 from .signals import password_reset, reset_password_instructions_sent
-from .utils import send_mail, md5, encrypt_password, url_for_security, \
+from .utils import send_mail, sha512, encrypt_password, url_for_security, \
     get_token_status, config_value
 
 
@@ -54,7 +54,7 @@ def generate_reset_password_token(user):
 
     :param user: The user to work with
     """
-    password_hash = md5(user.password) if user.password else None
+    password_hash = sha512(user.password) if user.password else None
     data = [str(user.id), password_hash]
     return _security.reset_serializer.dumps(data)
 
@@ -71,7 +71,7 @@ def reset_password_token_status(token):
                                                     return_data=True)
     if not invalid:
         if user.password:
-            password_hash = md5(user.password)
+            password_hash = sha512(user.password)
             if not safe_str_cmp(password_hash, data[1]):
                 invalid = True
 

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -168,7 +168,6 @@ def hash_data(data):
     ctx = CryptContext(schemes=['sha512_crypt', 'hex_md5'],
                        deprecated=['hex_md5'])
     return ctx.hash(encode_string(data))
-    # return hashlib.sha512(encode_string(data)).hexdigest()
 
 
 def verify_hash(hashed_data, compare_data):

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -163,8 +163,8 @@ def encode_string(string):
     return string
 
 
-def md5(data):
-    return hashlib.md5(encode_string(data)).hexdigest()
+def sha512(data):
+    return hashlib.sha512(encode_string(data)).hexdigest()
 
 
 def do_flash(message, category=None):

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -13,6 +13,7 @@ import base64
 import hashlib
 import hmac
 import sys
+from passlib.context import CryptContext
 
 try:
     from urlparse import urlsplit
@@ -163,8 +164,17 @@ def encode_string(string):
     return string
 
 
-def sha512(data):
-    return hashlib.sha512(encode_string(data)).hexdigest()
+def hash_data(data):
+    ctx = CryptContext(schemes=['sha512_crypt', 'hex_md5'],
+                       deprecated=['hex_md5'])
+    return ctx.hash(encode_string(data))
+    # return hashlib.sha512(encode_string(data)).hexdigest()
+
+
+def verify_hash(hashed_data, compare_data):
+    ctx = CryptContext(schemes=['sha512_crypt', 'hex_md5'],
+                       deprecated=['hex_md5'])
+    return ctx.verify(compare_data, hashed_data)
 
 
 def do_flash(message, category=None):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -13,7 +13,8 @@ from flask_security.forms import LoginForm, RegisterForm, ConfirmRegisterForm, \
     SendConfirmationForm, PasswordlessLoginForm, ForgotPasswordForm, ResetPasswordForm, \
     ChangePasswordForm, StringField, PasswordField, email_required, email_validator, \
     valid_user_email
-from flask_security.utils import capture_reset_password_requests, hash_data, string_types
+from flask_security.utils import capture_reset_password_requests, hash_data, \
+    string_types, verify_hash
 
 from utils import authenticate, init_app_with_options, populate_data
 
@@ -183,6 +184,12 @@ def test_hash_data():
     assert isinstance(data, string_types)
     data = hash_data(u'hellö')
     assert isinstance(data, string_types)
+
+
+def test_verify_hash():
+    data = hash_data(u'hellö')
+    assert verify_hash(data, u'hellö') is True
+    assert verify_hash(data, u'hello') is False
 
 
 @pytest.mark.settings(password_salt=u'öööööööööööööööööööööööööööööööööö',

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -13,7 +13,7 @@ from flask_security.forms import LoginForm, RegisterForm, ConfirmRegisterForm, \
     SendConfirmationForm, PasswordlessLoginForm, ForgotPasswordForm, ResetPasswordForm, \
     ChangePasswordForm, StringField, PasswordField, email_required, email_validator, \
     valid_user_email
-from flask_security.utils import capture_reset_password_requests, md5, string_types
+from flask_security.utils import capture_reset_password_requests, sha512, string_types
 
 from utils import authenticate, init_app_with_options, populate_data
 
@@ -179,9 +179,9 @@ def test_change_hash_type(app, sqlalchemy_datastore):
 
 
 def test_md5():
-    data = md5(b'hello')
+    data = sha512(b'hello')
     assert isinstance(data, string_types)
-    data = md5(u'hellö')
+    data = sha512(u'hellö')
     assert isinstance(data, string_types)
 
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -13,7 +13,7 @@ from flask_security.forms import LoginForm, RegisterForm, ConfirmRegisterForm, \
     SendConfirmationForm, PasswordlessLoginForm, ForgotPasswordForm, ResetPasswordForm, \
     ChangePasswordForm, StringField, PasswordField, email_required, email_validator, \
     valid_user_email
-from flask_security.utils import capture_reset_password_requests, sha512, string_types
+from flask_security.utils import capture_reset_password_requests, hash_data, string_types
 
 from utils import authenticate, init_app_with_options, populate_data
 
@@ -178,10 +178,10 @@ def test_change_hash_type(app, sqlalchemy_datastore):
     assert response.status_code == 302
 
 
-def test_md5():
-    data = sha512(b'hello')
+def test_hash_data():
+    data = hash_data(b'hello')
     assert isinstance(data, string_types)
-    data = sha512(u'hellö')
+    data = hash_data(u'hellö')
     assert isinstance(data, string_types)
 
 


### PR DESCRIPTION
Use sha512 instead of md5 for any hashing operation. MD5 is completely broken and should not be used for anything related to password. Even using MD5 to share password hashes should be treated as if giving the hashes in plaintext.