### PR TITLE
Add Chinese translation files of documents

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,10 @@ release = version
 # for a list of supported languages.
 #language = None
 
+# i18n
+locale_dirs = ['locale/']
+gettext_compact = False
+
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
 #today = ''
@@ -303,13 +307,13 @@ pygments_style = 'flask_theme_support.FlaskyStyle'
 # fall back if theme is not there
 try:
     __import__('flask_theme_support')
-except ImportError, e:
-    print '-' * 74
-    print 'Warning: Flask themes unavailable.  Building with default theme'
-    print 'If you want the Flask themes, run this command and build again:'
-    print
-    print '  git submodule update --init'
-    print '-' * 74
+except ImportError:
+    print('-' * 74)
+    print('Warning: Flask themes unavailable.  Building with default theme')
+    print('If you want the Flask themes, run this command and build again:')
+    print()
+    print('  git submodule update --init')
+    print('-' * 74)
 
     pygments_style = 'tango'
     html_theme = 'default'

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -166,7 +166,7 @@ Feature Flags
                           option. Defaults to ``False``.
 ``SECURITY_TRACKABLE``    Specifies if Flask-Security should track basic user
                           login statistics. If set to ``True``, ensure your
-                          models have the required fields/attribues. Be sure to
+                          models have the required fields/attributes. Be sure to
                           use `ProxyFix <http://flask.pocoo.org/docs/0.10/deploying/wsgi-standalone/#proxy-setups>` if you are using a proxy. Defaults to
                           ``False``
 ``SECURITY_PASSWORDLESS`` Specifies if Flask-Security should enable the

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -167,7 +167,7 @@ Feature Flags
 ``SECURITY_TRACKABLE``    Specifies if Flask-Security should track basic user
                           login statistics. If set to ``True``, ensure your
                           models have the required fields/attributes. Be sure to
-                          use `ProxyFix <http://flask.pocoo.org/docs/0.10/deploying/wsgi-standalone/#proxy-setups>` if you are using a proxy. Defaults to
+                          use `ProxyFix <http://flask.pocoo.org/docs/0.10/deploying/wsgi-standalone/#proxy-setups>`_ if you are using a proxy. Defaults to
                           ``False``
 ``SECURITY_PASSWORDLESS`` Specifies if Flask-Security should enable the
                           passwordless login feature. If set to ``True``, users

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -58,7 +58,7 @@ The following is a list of all the available context processor decorators:
 * ``login_context_processor``: Login view
 * ``register_context_processor``: Register view
 * ``reset_password_context_processor``: Reset password view
-* ``change_password_context_processor``: Reset password view
+* ``change_password_context_processor``: Change password view
 * ``send_confirmation_context_processor``: Send confirmation view
 * ``send_login_context_processor``: Send login view
 
@@ -98,7 +98,7 @@ The following is a list of all the available form overrides:
 * ``register_form``: Register form
 * ``forgot_password_form``: Forgot password form
 * ``reset_password_form``: Reset password form
-* ``change_password_form``: Reset password form
+* ``change_password_form``: Change password form
 * ``send_confirmation_form``: Send confirmation form
 * ``passwordless_login_form``: Passwordless login form
 

--- a/docs/locale/zh-CN/LC_MESSAGES/api.po
+++ b/docs/locale/zh-CN/LC_MESSAGES/api.po
@@ -4,57 +4,60 @@
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 1.7.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-28 10:58+0800\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"POT-Creation-Date: 2017-03-27 11:45+0800\n"
+"PO-Revision-Date: 2017-03-28 15:07+0800\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.4.0\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: zh_CN\n"
+"X-Generator: Poedit 1.8.6\n"
 
 #: ../../api.rst:2
 msgid "API"
-msgstr ""
+msgstr "API"
 
 #: ../../api.rst:5
 msgid "Core"
-msgstr ""
+msgstr "核心"
 
 #: ../../api.rst:11
 msgid "A proxy for the current user."
-msgstr ""
+msgstr "current user 的代理( proxy )"
 
 #: ../../api.rst:15
 msgid "Protecting Views"
-msgstr ""
+msgstr "保护的视图"
 
 #: ../../api.rst:28
 msgid "User Object Helpers"
-msgstr ""
+msgstr "用户对象助手"
 
 #: ../../api.rst:40
 msgid "Datastores"
-msgstr ""
+msgstr "数据储存"
 
 #: ../../api.rst:58
 msgid "Utils"
-msgstr ""
+msgstr "实用工具"
 
 #: ../../api.rst:80
 msgid "Signals"
-msgstr ""
+msgstr "信号"
 
 #: ../../api.rst:81
 msgid ""
 "See the `Flask documentation on signals`_ for information on how to use "
 "these signals in your code."
 msgstr ""
+"查看 `Flask documentation on signals`_  从中获取更多关于如何在你的代码中"
+"使用信号的信息."
 
 #: ../../api.rst:84
 msgid ""
@@ -62,47 +65,57 @@ msgid ""
 "Flask-Principal extensions. In addition to those signals, Flask-Security "
 "sends the following signals."
 msgstr ""
+"查看 Flask-Login and Flask-Principal 扩展所提供的信号的文档. 除了这些信"
+"号, Flask-Security 发送如下信号:"
 
 #: ../../api.rst:90
 msgid ""
 "Sent when a user registers on the site. In addition to the app (which is "
 "the sender), it is passed `user` and `confirm_token` arguments."
 msgstr ""
+"当一个用户在网站注册时发送. 除了应用 ( 发送者 ),  它被传递  `user` 和 "
+"`confirm_token` 参数."
 
 #: ../../api.rst:95
 msgid ""
 "Sent when a user is confirmed. In addition to the app (which is the "
 "sender), it is passed a `user` argument."
-msgstr ""
+msgstr "当一个用户被验证. 除了应用 ( 发送者 ),  它被传递  `user` 参数."
 
 #: ../../api.rst:100
 msgid ""
 "Sent when a user requests confirmation instructions. In addition to the "
 "app (which is the sender), it is passed a `user` argument."
 msgstr ""
+"当一个用户请求验证指令. 除了应用 ( 发送者 ),  它被传递  `user` 参数."
 
 #: ../../api.rst:105
 msgid ""
-"Sent when passwordless login is used and user logs in. In addition to the"
-" app (which is the sender), it is passed `user` and `login_token` "
+"Sent when passwordless login is used and user logs in. In addition to "
+"the app (which is the sender), it is passed `user` and `login_token` "
 "arguments."
 msgstr ""
+"当一个无密码登录被使用和用户登录时. 除了应用 ( 发送者 ),  它被传递  "
+"`user` 和 `login_token` 参数."
 
 #: ../../api.rst:110
 msgid ""
 "Sent when a user completes a password reset. In addition to the app "
 "(which is the sender), it is passed a `user` argument."
 msgstr ""
+"当一个用户完成密码重置时. 除了应用 ( 发送者 ),  它被传递  `user` 参数."
 
 #: ../../api.rst:115
 msgid ""
 "Sent when a user completes a password change. In addition to the app "
 "(which is the sender), it is passed a `user` argument."
 msgstr ""
+"当一个用户完成密码修改时. 除了应用 ( 发送者 ),  它被传递  `user` 参数."
 
 #: ../../api.rst:120
 msgid ""
-"Sent when a user requests a password reset. In addition to the app (which"
-" is the sender), it is passed `user` and `token` arguments."
+"Sent when a user requests a password reset. In addition to the app "
+"(which is the sender), it is passed `user` and `token` arguments."
 msgstr ""
-
+"当一个用户请求重置密码时. 除了应用 ( 发送者 ),  它被传递  `user` 和 "
+"`token` 参数."

--- a/docs/locale/zh-CN/LC_MESSAGES/api.po
+++ b/docs/locale/zh-CN/LC_MESSAGES/api.po
@@ -1,0 +1,108 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2012, Matt Wright
+# This file is distributed under the same license as the Flask-Security
+# package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Flask-Security 1.7.5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-03-28 10:58+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.4.0\n"
+
+#: ../../api.rst:2
+msgid "API"
+msgstr ""
+
+#: ../../api.rst:5
+msgid "Core"
+msgstr ""
+
+#: ../../api.rst:11
+msgid "A proxy for the current user."
+msgstr ""
+
+#: ../../api.rst:15
+msgid "Protecting Views"
+msgstr ""
+
+#: ../../api.rst:28
+msgid "User Object Helpers"
+msgstr ""
+
+#: ../../api.rst:40
+msgid "Datastores"
+msgstr ""
+
+#: ../../api.rst:58
+msgid "Utils"
+msgstr ""
+
+#: ../../api.rst:80
+msgid "Signals"
+msgstr ""
+
+#: ../../api.rst:81
+msgid ""
+"See the `Flask documentation on signals`_ for information on how to use "
+"these signals in your code."
+msgstr ""
+
+#: ../../api.rst:84
+msgid ""
+"See the documentation for the signals provided by the Flask-Login and "
+"Flask-Principal extensions. In addition to those signals, Flask-Security "
+"sends the following signals."
+msgstr ""
+
+#: ../../api.rst:90
+msgid ""
+"Sent when a user registers on the site. In addition to the app (which is "
+"the sender), it is passed `user` and `confirm_token` arguments."
+msgstr ""
+
+#: ../../api.rst:95
+msgid ""
+"Sent when a user is confirmed. In addition to the app (which is the "
+"sender), it is passed a `user` argument."
+msgstr ""
+
+#: ../../api.rst:100
+msgid ""
+"Sent when a user requests confirmation instructions. In addition to the "
+"app (which is the sender), it is passed a `user` argument."
+msgstr ""
+
+#: ../../api.rst:105
+msgid ""
+"Sent when passwordless login is used and user logs in. In addition to the"
+" app (which is the sender), it is passed `user` and `login_token` "
+"arguments."
+msgstr ""
+
+#: ../../api.rst:110
+msgid ""
+"Sent when a user completes a password reset. In addition to the app "
+"(which is the sender), it is passed a `user` argument."
+msgstr ""
+
+#: ../../api.rst:115
+msgid ""
+"Sent when a user completes a password change. In addition to the app "
+"(which is the sender), it is passed a `user` argument."
+msgstr ""
+
+#: ../../api.rst:120
+msgid ""
+"Sent when a user requests a password reset. In addition to the app (which"
+" is the sender), it is passed `user` and `token` arguments."
+msgstr ""
+

--- a/docs/locale/zh-CN/LC_MESSAGES/authors.po
+++ b/docs/locale/zh-CN/LC_MESSAGES/authors.po
@@ -1,0 +1,48 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2012, Matt Wright
+# This file is distributed under the same license as the Flask-Security
+# package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Flask-Security 1.7.5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-03-28 10:58+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.4.0\n"
+
+#: ../../../AUTHORS:1
+msgid ""
+"Flask-Security is written and maintained by Matt Wright and various "
+"contributors:"
+msgstr ""
+
+#: ../../../AUTHORS:5
+msgid "Development Lead"
+msgstr ""
+
+#: ../../../AUTHORS:7
+msgid "Matt Wright <matt+github@nobien.net>"
+msgstr ""
+
+#: ../../../AUTHORS:10
+msgid "Patches and Suggestions"
+msgstr ""
+
+#: ../../../AUTHORS:12
+msgid ""
+"Alexander Sukharev Alexey Poryadin Andrew J. Camenga Anthony Plunkett "
+"Artem Andreev Catherine Wise Chris Haines Christophe Simonis David "
+"Ignacio Eric Butler Eskil Heyn Olsen Iuri de Silvio Jay Goel Joe Esposito"
+" Joe Hand Josh Purvis Kostyantyn Leschenko Luca Invernizzi Manuel Ebert "
+"Martin Maillard Paweł Krześniak Robert Clark Rodrigue Cloutier Rotem "
+"Yaari Srijan Choudhary Tristan Escalada Vadim Kotov Walt Askew"
+msgstr ""
+

--- a/docs/locale/zh-CN/LC_MESSAGES/authors.po
+++ b/docs/locale/zh-CN/LC_MESSAGES/authors.po
@@ -4,45 +4,53 @@
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 1.7.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-28 10:58+0800\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"POT-Creation-Date: 2017-03-27 11:45+0800\n"
+"PO-Revision-Date: 2017-03-27 15:36+0800\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.4.0\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: zh_CN\n"
+"X-Generator: Poedit 1.8.6\n"
 
 #: ../../../AUTHORS:1
 msgid ""
 "Flask-Security is written and maintained by Matt Wright and various "
 "contributors:"
-msgstr ""
+msgstr "Flask-Security 由 Matt Wright 和众多参与者编写并维护:"
 
 #: ../../../AUTHORS:5
 msgid "Development Lead"
-msgstr ""
+msgstr "开发领头人"
 
 #: ../../../AUTHORS:7
 msgid "Matt Wright <matt+github@nobien.net>"
-msgstr ""
+msgstr "Matt Wright <matt+github@nobien.net>"
 
 #: ../../../AUTHORS:10
 msgid "Patches and Suggestions"
-msgstr ""
+msgstr "补丁和建议"
 
 #: ../../../AUTHORS:12
 msgid ""
 "Alexander Sukharev Alexey Poryadin Andrew J. Camenga Anthony Plunkett "
 "Artem Andreev Catherine Wise Chris Haines Christophe Simonis David "
-"Ignacio Eric Butler Eskil Heyn Olsen Iuri de Silvio Jay Goel Joe Esposito"
-" Joe Hand Josh Purvis Kostyantyn Leschenko Luca Invernizzi Manuel Ebert "
-"Martin Maillard Paweł Krześniak Robert Clark Rodrigue Cloutier Rotem "
-"Yaari Srijan Choudhary Tristan Escalada Vadim Kotov Walt Askew"
+"Ignacio Eric Butler Eskil Heyn Olsen Iuri de Silvio Jay Goel Joe "
+"Esposito Joe Hand Josh Purvis Kostyantyn Leschenko Luca Invernizzi "
+"Manuel Ebert Martin Maillard Paweł Krześniak Robert Clark Rodrigue "
+"Cloutier Rotem Yaari Srijan Choudhary Tristan Escalada Vadim Kotov Walt "
+"Askew"
 msgstr ""
-
+"Alexander Sukharev Alexey Poryadin Andrew J. Camenga Anthony Plunkett "
+"Artem Andreev Catherine Wise Chris Haines Christophe Simonis David "
+"Ignacio Eric Butler Eskil Heyn Olsen Iuri de Silvio Jay Goel Joe "
+"Esposito Joe Hand Josh Purvis Kostyantyn Leschenko Luca Invernizzi "
+"Manuel Ebert Martin Maillard Paweł Krześniak Robert Clark Rodrigue "
+"Cloutier Rotem Yaari Srijan Choudhary Tristan Escalada Vadim Kotov Walt "
+"Askew"

--- a/docs/locale/zh-CN/LC_MESSAGES/changelog.po
+++ b/docs/locale/zh-CN/LC_MESSAGES/changelog.po
@@ -4,19 +4,20 @@
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 1.7.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-28 10:58+0800\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"POT-Creation-Date: 2017-03-27 11:45+0800\n"
+"PO-Revision-Date: 2017-03-27 13:26+0800\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.4.0\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: zh_CN\n"
+"X-Generator: Poedit 1.8.6\n"
 
 #: ../../../CHANGES:2
 msgid "Flask-Security Changelog"
@@ -24,8 +25,7 @@ msgstr ""
 
 #: ../../../CHANGES:4
 msgid ""
-"Here you can see the full list of changes between each Flask-Security "
-"release."
+"Here you can see the full list of changes between each Flask-Security release."
 msgstr ""
 
 #: ../../../CHANGES:7
@@ -42,8 +42,8 @@ msgstr ""
 
 #: ../../../CHANGES:12
 msgid ""
-"Fixed calls to `SQLAlchemyUserDatastore.get_user(None)` (this now returns"
-" `False` instead of raising a `TypeError`"
+"Fixed calls to `SQLAlchemyUserDatastore.get_user(None)` (this now returns "
+"`False` instead of raising a `TypeError`"
 msgstr ""
 
 #: ../../../CHANGES:13
@@ -52,8 +52,8 @@ msgstr ""
 
 #: ../../../CHANGES:14
 msgid ""
-"Fixed handling of trackable IP addresses when the `X-Forwarded-For` "
-"header contains multiple values"
+"Fixed handling of trackable IP addresses when the `X-Forwarded-For` header "
+"contains multiple values"
 msgstr ""
 
 #: ../../../CHANGES:15
@@ -86,8 +86,8 @@ msgstr ""
 
 #: ../../../CHANGES:22
 msgid ""
-"Updated `is_authenticated` and `is_active` functions to support Flask-"
-"Login changes"
+"Updated `is_authenticated` and `is_active` functions to support Flask-Login "
+"changes"
 msgstr ""
 
 #: ../../../CHANGES:23
@@ -104,8 +104,7 @@ msgstr ""
 
 #: ../../../CHANGES:31
 msgid ""
-"Fixed a bug related to changing existing passwords from plaintext to "
-"hashed"
+"Fixed a bug related to changing existing passwords from plaintext to hashed"
 msgstr ""
 
 #: ../../../CHANGES:32
@@ -126,8 +125,7 @@ msgstr ""
 
 #: ../../../CHANGES:41
 msgid ""
-"Fixed a bug where redirection to `SECURITY_POST_LOGIN_VIEW` was not "
-"respected"
+"Fixed a bug where redirection to `SECURITY_POST_LOGIN_VIEW` was not respected"
 msgstr ""
 
 #: ../../../CHANGES:42
@@ -176,8 +174,8 @@ msgstr ""
 
 #: ../../../CHANGES:63
 msgid ""
-"Fixed a bug where passwords would fail to verify when specifying a "
-"password hash algorithm"
+"Fixed a bug where passwords would fail to verify when specifying a password "
+"hash algorithm"
 msgstr ""
 
 #: ../../../CHANGES:67
@@ -198,14 +196,14 @@ msgstr ""
 
 #: ../../../CHANGES:73
 msgid ""
-"Fixed a bug when `SECURITY_LOGIN_WITHOUT_CONFIRMATION = True` did not "
-"allow users to log in"
+"Fixed a bug when `SECURITY_LOGIN_WITHOUT_CONFIRMATION = True` did not allow "
+"users to log in"
 msgstr ""
 
 #: ../../../CHANGES:74
 msgid ""
-"Added `SECURITY_SEND_PASSWORD_RESET_NOTICE_EMAIL` configuraiton option to"
-" optionally send password reset notice emails"
+"Added `SECURITY_SEND_PASSWORD_RESET_NOTICE_EMAIL` configuraiton option to "
+"optionally send password reset notice emails"
 msgstr ""
 
 #: ../../../CHANGES:75
@@ -222,8 +220,7 @@ msgstr ""
 
 #: ../../../CHANGES:78
 msgid ""
-"Added documentation for select functions in the `flask_security.utils` "
-"module"
+"Added documentation for select functions in the `flask_security.utils` module"
 msgstr ""
 
 #: ../../../CHANGES:79
@@ -232,34 +229,33 @@ msgstr ""
 
 #: ../../../CHANGES:80
 msgid ""
-"Added `CHANGE_PASSWORD_TEMPLATE` configuration option to optionally "
-"specify a different change password template"
+"Added `CHANGE_PASSWORD_TEMPLATE` configuration option to optionally specify a "
+"different change password template"
 msgstr ""
 
 #: ../../../CHANGES:81
 msgid ""
-"Added the ability to specify addtional fields on the user model to be "
-"used for identifying the user via the `USER_IDENTITY_ATTRIBUTES` "
-"configuration option"
+"Added the ability to specify addtional fields on the user model to be used for "
+"identifying the user via the `USER_IDENTITY_ATTRIBUTES` configuration option"
 msgstr ""
 
 #: ../../../CHANGES:82
 msgid ""
-"An error is now shown if a user tries to change their password and the "
-"password is the same as before. The message can be customed with the "
+"An error is now shown if a user tries to change their password and the password "
+"is the same as before. The message can be customed with the "
 "`SECURITY_MSG_PASSWORD_IS_SAME` configuration option"
 msgstr ""
 
 #: ../../../CHANGES:83
 msgid ""
-"Fixed a bug in `MongoEngineUserDatastore` where user model would not be "
-"updated when using the `add_role_to_user` method"
+"Fixed a bug in `MongoEngineUserDatastore` where user model would not be updated "
+"when using the `add_role_to_user` method"
 msgstr ""
 
 #: ../../../CHANGES:84
 msgid ""
-"Added `SECURITY_SEND_PASSWORD_CHANGE_EMAIL` configuration option to "
-"optionally disable password change email from being sent"
+"Added `SECURITY_SEND_PASSWORD_CHANGE_EMAIL` configuration option to optionally "
+"disable password change email from being sent"
 msgstr ""
 
 #: ../../../CHANGES:85
@@ -326,8 +322,7 @@ msgstr ""
 
 #: ../../../CHANGES:110
 msgid ""
-"Ignore validation errors in find_user function for "
-"MongoEngineUserDatastore"
+"Ignore validation errors in find_user function for MongoEngineUserDatastore"
 msgstr ""
 
 #: ../../../CHANGES:114
@@ -344,8 +339,8 @@ msgstr ""
 
 #: ../../../CHANGES:119
 msgid ""
-"Fixed email confirmation bug that prevented logged in users from "
-"confirming their email"
+"Fixed email confirmation bug that prevented logged in users from confirming "
+"their email"
 msgstr ""
 
 #: ../../../CHANGES:123
@@ -382,8 +377,8 @@ msgstr ""
 
 #: ../../../CHANGES:143
 msgid ""
-"Added `SECURITY_DEFAULT_REMEMBER_ME` configuration value to unify "
-"behavior between endpoints"
+"Added `SECURITY_DEFAULT_REMEMBER_ME` configuration value to unify behavior "
+"between endpoints"
 msgstr ""
 
 #: ../../../CHANGES:144
@@ -392,8 +387,8 @@ msgstr ""
 
 #: ../../../CHANGES:145
 msgid ""
-"Added optional `next` parameter to registration endpoint, similar to that"
-" of login"
+"Added optional `next` parameter to registration endpoint, similar to that of "
+"login"
 msgstr ""
 
 #: ../../../CHANGES:149
@@ -446,8 +441,8 @@ msgstr ""
 
 #: ../../../CHANGES:178
 msgid ""
-"Password hashing is now more flexible and can be changed to a different "
-"type at will"
+"Password hashing is now more flexible and can be changed to a different type at "
+"will"
 msgstr ""
 
 #: ../../../CHANGES:179
@@ -472,8 +467,8 @@ msgstr ""
 
 #: ../../../CHANGES:184
 msgid ""
-"Added the user to the request context when successfully authenticated via"
-" http basic and token auth"
+"Added the user to the request context when successfully authenticated via http "
+"basic and token auth"
 msgstr ""
 
 #: ../../../CHANGES:185
@@ -482,8 +477,7 @@ msgstr ""
 
 #: ../../../CHANGES:186
 msgid ""
-"Redirects to other domains are now not allowed during requests that may "
-"redirect"
+"Redirects to other domains are now not allowed during requests that may redirect"
 msgstr ""
 
 #: ../../../CHANGES:187
@@ -512,8 +506,8 @@ msgstr ""
 
 #: ../../../CHANGES:198
 msgid ""
-"Fix bug in forms with `csrf_enabled` parameter not accounting attempts to"
-" login using JSON data"
+"Fix bug in forms with `csrf_enabled` parameter not accounting attempts to login "
+"using JSON data"
 msgstr ""
 
 #: ../../../CHANGES:202
@@ -570,9 +564,9 @@ msgstr ""
 
 #: ../../../CHANGES:229
 msgid ""
-"Major release. Upgrading from previous versions will require a bit of "
-"work to accomodate API changes. See documentation for a list of new "
-"features and for help on how to upgrade."
+"Major release. Upgrading from previous versions will require a bit of work to "
+"accomodate API changes. See documentation for a list of new features and for "
+"help on how to upgrade."
 msgstr ""
 
 #: ../../../CHANGES:234
@@ -597,8 +591,8 @@ msgstr ""
 
 #: ../../../CHANGES:245
 msgid ""
-"Fixed bug where `roles_required` and `roles_accepted` did not pass the "
-"next argument to the login view"
+"Fixed bug where `roles_required` and `roles_accepted` did not pass the next "
+"argument to the login view"
 msgstr ""
 
 #: ../../../CHANGES:249
@@ -627,9 +621,8 @@ msgstr ""
 
 #: ../../../CHANGES:261
 msgid ""
-"Added configuration option `SECURITY_FLASH_MESSAGES` which can be set to "
-"a boolean value to specify if Flask-Security should flash messages or "
-"not."
+"Added configuration option `SECURITY_FLASH_MESSAGES` which can be set to a "
+"boolean value to specify if Flask-Security should flash messages or not."
 msgstr ""
 
 #: ../../../CHANGES:265
@@ -639,4 +632,3 @@ msgstr ""
 #: ../../../CHANGES:267
 msgid "Initial release"
 msgstr ""
-

--- a/docs/locale/zh-CN/LC_MESSAGES/changelog.po
+++ b/docs/locale/zh-CN/LC_MESSAGES/changelog.po
@@ -1,0 +1,642 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2012, Matt Wright
+# This file is distributed under the same license as the Flask-Security
+# package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Flask-Security 1.7.5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-03-28 10:58+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.4.0\n"
+
+#: ../../../CHANGES:2
+msgid "Flask-Security Changelog"
+msgstr ""
+
+#: ../../../CHANGES:4
+msgid ""
+"Here you can see the full list of changes between each Flask-Security "
+"release."
+msgstr ""
+
+#: ../../../CHANGES:7
+msgid "Version 1.7.5"
+msgstr ""
+
+#: ../../../CHANGES:9
+msgid "Released December 2nd 2015"
+msgstr ""
+
+#: ../../../CHANGES:11
+msgid "Added `SECURITY_TOKEN_MAX_AGE` configuration setting"
+msgstr ""
+
+#: ../../../CHANGES:12
+msgid ""
+"Fixed calls to `SQLAlchemyUserDatastore.get_user(None)` (this now returns"
+" `False` instead of raising a `TypeError`"
+msgstr ""
+
+#: ../../../CHANGES:13
+msgid "Fixed URL generation adding extra slashes in some cases (see GitHub #343)"
+msgstr ""
+
+#: ../../../CHANGES:14
+msgid ""
+"Fixed handling of trackable IP addresses when the `X-Forwarded-For` "
+"header contains multiple values"
+msgstr ""
+
+#: ../../../CHANGES:15
+msgid "Include WWW-Authenticate headers in `@auth_required` authentication checks"
+msgstr ""
+
+#: ../../../CHANGES:16
+msgid "Fixed error when `check_token` function is used with a json list"
+msgstr ""
+
+#: ../../../CHANGES:17
+msgid "Added support for custom `AnonymousUser` classes"
+msgstr ""
+
+#: ../../../CHANGES:18
+msgid "Restricted `forgot_password` endpoint to anonymous users"
+msgstr ""
+
+#: ../../../CHANGES:19
+msgid "Allowed unauthorized callback to be overridden"
+msgstr ""
+
+#: ../../../CHANGES:20
+msgid "Fixed issue where passwords cannot be reset if currently set to `None`"
+msgstr ""
+
+#: ../../../CHANGES:21
+msgid "Ensured that password reset tokens are invalidated after use"
+msgstr ""
+
+#: ../../../CHANGES:22
+msgid ""
+"Updated `is_authenticated` and `is_active` functions to support Flask-"
+"Login changes"
+msgstr ""
+
+#: ../../../CHANGES:23
+msgid "Various documentation improvements"
+msgstr ""
+
+#: ../../../CHANGES:27
+msgid "Version 1.7.4"
+msgstr ""
+
+#: ../../../CHANGES:29
+msgid "Released October 13th 2014"
+msgstr ""
+
+#: ../../../CHANGES:31
+msgid ""
+"Fixed a bug related to changing existing passwords from plaintext to "
+"hashed"
+msgstr ""
+
+#: ../../../CHANGES:32
+msgid "Fixed a bug in form validation that did not enforce case insensivitiy"
+msgstr ""
+
+#: ../../../CHANGES:33
+msgid "Fixed a bug with validating redirects"
+msgstr ""
+
+#: ../../../CHANGES:37
+msgid "Version 1.7.3"
+msgstr ""
+
+#: ../../../CHANGES:39
+msgid "Released June 10th 2014"
+msgstr ""
+
+#: ../../../CHANGES:41
+msgid ""
+"Fixed a bug where redirection to `SECURITY_POST_LOGIN_VIEW` was not "
+"respected"
+msgstr ""
+
+#: ../../../CHANGES:42
+msgid "Fixed string encoding in various places to be friendly to unicode"
+msgstr ""
+
+#: ../../../CHANGES:43
+msgid "Now using `werkzeug.security.safe_str_cmp` to check tokens"
+msgstr ""
+
+#: ../../../CHANGES:44
+msgid "Removed user information from JSON output on `/reset` responses"
+msgstr ""
+
+#: ../../../CHANGES:45
+msgid "Added Python 3.4 support"
+msgstr ""
+
+#: ../../../CHANGES:49
+msgid "Version 1.7.2"
+msgstr ""
+
+#: ../../../CHANGES:51
+msgid "Released May 6th 2014"
+msgstr ""
+
+#: ../../../CHANGES:53
+msgid "Updated IP tracking to check for `X-Forwarded-For` header"
+msgstr ""
+
+#: ../../../CHANGES:54
+msgid "Fixed a bug regarding the re-hashing of passwords with a new algorithm"
+msgstr ""
+
+#: ../../../CHANGES:55
+msgid "Fixed a bug regarding the `password_changed` signal."
+msgstr ""
+
+#: ../../../CHANGES:59
+msgid "Version 1.7.1"
+msgstr ""
+
+#: ../../../CHANGES:61
+msgid "Released January 14th 2014"
+msgstr ""
+
+#: ../../../CHANGES:63
+msgid ""
+"Fixed a bug where passwords would fail to verify when specifying a "
+"password hash algorithm"
+msgstr ""
+
+#: ../../../CHANGES:67
+msgid "Version 1.7.0"
+msgstr ""
+
+#: ../../../CHANGES:69
+msgid "Released January 10th 2014"
+msgstr ""
+
+#: ../../../CHANGES:71
+msgid "Python 3.3 support!"
+msgstr ""
+
+#: ../../../CHANGES:72
+msgid "Dependency updates"
+msgstr ""
+
+#: ../../../CHANGES:73
+msgid ""
+"Fixed a bug when `SECURITY_LOGIN_WITHOUT_CONFIRMATION = True` did not "
+"allow users to log in"
+msgstr ""
+
+#: ../../../CHANGES:74
+msgid ""
+"Added `SECURITY_SEND_PASSWORD_RESET_NOTICE_EMAIL` configuraiton option to"
+" optionally send password reset notice emails"
+msgstr ""
+
+#: ../../../CHANGES:75
+msgid "Add documentation for `@security.send_mail_task`"
+msgstr ""
+
+#: ../../../CHANGES:76
+msgid "Move to `request.get_json` as `request.json` is now deprecated in Flask"
+msgstr ""
+
+#: ../../../CHANGES:77
+msgid "Fixed a bug when using AJAX to change a user's password"
+msgstr ""
+
+#: ../../../CHANGES:78
+msgid ""
+"Added documentation for select functions in the `flask_security.utils` "
+"module"
+msgstr ""
+
+#: ../../../CHANGES:79
+msgid "Fixed a bug in `flask_security.forms.NextFormMixin`"
+msgstr ""
+
+#: ../../../CHANGES:80
+msgid ""
+"Added `CHANGE_PASSWORD_TEMPLATE` configuration option to optionally "
+"specify a different change password template"
+msgstr ""
+
+#: ../../../CHANGES:81
+msgid ""
+"Added the ability to specify addtional fields on the user model to be "
+"used for identifying the user via the `USER_IDENTITY_ATTRIBUTES` "
+"configuration option"
+msgstr ""
+
+#: ../../../CHANGES:82
+msgid ""
+"An error is now shown if a user tries to change their password and the "
+"password is the same as before. The message can be customed with the "
+"`SECURITY_MSG_PASSWORD_IS_SAME` configuration option"
+msgstr ""
+
+#: ../../../CHANGES:83
+msgid ""
+"Fixed a bug in `MongoEngineUserDatastore` where user model would not be "
+"updated when using the `add_role_to_user` method"
+msgstr ""
+
+#: ../../../CHANGES:84
+msgid ""
+"Added `SECURITY_SEND_PASSWORD_CHANGE_EMAIL` configuration option to "
+"optionally disable password change email from being sent"
+msgstr ""
+
+#: ../../../CHANGES:85
+msgid "Fixed a bug in the `find_or_create_role` method of the PeeWee datastore"
+msgstr ""
+
+#: ../../../CHANGES:86
+msgid "Removed pypy tests"
+msgstr ""
+
+#: ../../../CHANGES:87
+msgid "Fixed some tests"
+msgstr ""
+
+#: ../../../CHANGES:88
+msgid "Include CHANGES and LICENSE in MANIFEST.in"
+msgstr ""
+
+#: ../../../CHANGES:89
+msgid "A bit of documentation cleanup"
+msgstr ""
+
+#: ../../../CHANGES:90
+msgid ""
+"A bit of code cleanup including removal of unnecessary utcnow call and "
+"simplification of get_max_age method"
+msgstr ""
+
+#: ../../../CHANGES:94
+msgid "Version 1.6.9"
+msgstr ""
+
+#: ../../../CHANGES:96
+msgid "Released August 20th 2013"
+msgstr ""
+
+#: ../../../CHANGES:98
+msgid "Fix bug in SQLAlchemy datastore's `get_user` function"
+msgstr ""
+
+#: ../../../CHANGES:99
+msgid "Fix bug in PeeWee datastore's `remove_role_from_user` function"
+msgstr ""
+
+#: ../../../CHANGES:100
+msgid "Fixed import error caused by new Flask-WTF release"
+msgstr ""
+
+#: ../../../CHANGES:104
+msgid "Version 1.6.8"
+msgstr ""
+
+#: ../../../CHANGES:106
+msgid "Released August 1st 2013"
+msgstr ""
+
+#: ../../../CHANGES:108
+msgid "Fixed bug with case sensitivity of email address during login"
+msgstr ""
+
+#: ../../../CHANGES:109
+msgid "Code cleanup regarding token_callback"
+msgstr ""
+
+#: ../../../CHANGES:110
+msgid ""
+"Ignore validation errors in find_user function for "
+"MongoEngineUserDatastore"
+msgstr ""
+
+#: ../../../CHANGES:114
+msgid "Version 1.6.7"
+msgstr ""
+
+#: ../../../CHANGES:116
+msgid "Released July 11th 2013"
+msgstr ""
+
+#: ../../../CHANGES:118
+msgid "Made password length form error message configurable"
+msgstr ""
+
+#: ../../../CHANGES:119
+msgid ""
+"Fixed email confirmation bug that prevented logged in users from "
+"confirming their email"
+msgstr ""
+
+#: ../../../CHANGES:123
+msgid "Version 1.6.6"
+msgstr ""
+
+#: ../../../CHANGES:125
+msgid "Released June 28th 2013"
+msgstr ""
+
+#: ../../../CHANGES:127
+msgid "Fixed dependency versions"
+msgstr ""
+
+#: ../../../CHANGES:131
+msgid "Version 1.6.5"
+msgstr ""
+
+#: ../../../CHANGES:133
+msgid "Released June 20th 2013"
+msgstr ""
+
+#: ../../../CHANGES:135
+msgid "Fixed bug in `flask.ext.security.confirmable.generate_confirmation_link`"
+msgstr ""
+
+#: ../../../CHANGES:139
+msgid "Version 1.6.4"
+msgstr ""
+
+#: ../../../CHANGES:141
+msgid "Released June 18th 2013"
+msgstr ""
+
+#: ../../../CHANGES:143
+msgid ""
+"Added `SECURITY_DEFAULT_REMEMBER_ME` configuration value to unify "
+"behavior between endpoints"
+msgstr ""
+
+#: ../../../CHANGES:144
+msgid "Fixed Flask-Login dependency problem"
+msgstr ""
+
+#: ../../../CHANGES:145
+msgid ""
+"Added optional `next` parameter to registration endpoint, similar to that"
+" of login"
+msgstr ""
+
+#: ../../../CHANGES:149
+msgid "Version 1.6.3"
+msgstr ""
+
+#: ../../../CHANGES:151
+msgid "Released May 8th 2013"
+msgstr ""
+
+#: ../../../CHANGES:153
+msgid "Fixed bug in regards to imports with latest version of MongoEngine"
+msgstr ""
+
+#: ../../../CHANGES:157
+msgid "Version 1.6.2"
+msgstr ""
+
+#: ../../../CHANGES:159
+msgid "Released April 4th 2013"
+msgstr ""
+
+#: ../../../CHANGES:161
+msgid "Fixed bug with http basic auth"
+msgstr ""
+
+#: ../../../CHANGES:165
+msgid "Version 1.6.1"
+msgstr ""
+
+#: ../../../CHANGES:167
+msgid "Released April 3rd 2013"
+msgstr ""
+
+#: ../../../CHANGES:169
+msgid "Fixed bug with signals"
+msgstr ""
+
+#: ../../../CHANGES:173
+msgid "Version 1.6.0"
+msgstr ""
+
+#: ../../../CHANGES:175
+msgid "Released March 13th 2013"
+msgstr ""
+
+#: ../../../CHANGES:177
+msgid "Added Flask-Pewee support"
+msgstr ""
+
+#: ../../../CHANGES:178
+msgid ""
+"Password hashing is now more flexible and can be changed to a different "
+"type at will"
+msgstr ""
+
+#: ../../../CHANGES:179
+msgid "Flask-Login messages are configurable"
+msgstr ""
+
+#: ../../../CHANGES:180
+msgid "AJAX requests must now send a CSRF token for security reasons"
+msgstr ""
+
+#: ../../../CHANGES:181
+msgid "Form messages are now configurable"
+msgstr ""
+
+#: ../../../CHANGES:182
+msgid "Forms can now be extended with more fields"
+msgstr ""
+
+#: ../../../CHANGES:183
+msgid "Added change password endpoint"
+msgstr ""
+
+#: ../../../CHANGES:184
+msgid ""
+"Added the user to the request context when successfully authenticated via"
+" http basic and token auth"
+msgstr ""
+
+#: ../../../CHANGES:185
+msgid "The Flask-Security blueprint subdomain is now configurable"
+msgstr ""
+
+#: ../../../CHANGES:186
+msgid ""
+"Redirects to other domains are now not allowed during requests that may "
+"redirect"
+msgstr ""
+
+#: ../../../CHANGES:187
+msgid "Template paths can be configured"
+msgstr ""
+
+#: ../../../CHANGES:188
+msgid "The welcome/register email can now optionally be sent to the user"
+msgstr ""
+
+#: ../../../CHANGES:189
+msgid "Passwords can now contain non-latin characters"
+msgstr ""
+
+#: ../../../CHANGES:190
+msgid "Fixed a bug when confirming an account but the account has been deleted"
+msgstr ""
+
+#: ../../../CHANGES:194
+msgid "Version 1.5.4"
+msgstr ""
+
+#: ../../../CHANGES:196
+msgid "Released January 6th 2013"
+msgstr ""
+
+#: ../../../CHANGES:198
+msgid ""
+"Fix bug in forms with `csrf_enabled` parameter not accounting attempts to"
+" login using JSON data"
+msgstr ""
+
+#: ../../../CHANGES:202
+msgid "Version 1.5.3"
+msgstr ""
+
+#: ../../../CHANGES:204
+msgid "Released December 23rd 2012"
+msgstr ""
+
+#: ../../../CHANGES:206
+msgid "Change dependency requirement"
+msgstr ""
+
+#: ../../../CHANGES:209
+msgid "Version 1.5.2"
+msgstr ""
+
+#: ../../../CHANGES:211
+msgid "Released December 11th 2012"
+msgstr ""
+
+#: ../../../CHANGES:213
+msgid "Fix a small bug in `flask_security.utils.login_user` method"
+msgstr ""
+
+#: ../../../CHANGES:216
+msgid "Version 1.5.1"
+msgstr ""
+
+#: ../../../CHANGES:218
+msgid "Released November 26th 2012"
+msgstr ""
+
+#: ../../../CHANGES:220
+msgid "Fixed bug with `next` form variable"
+msgstr ""
+
+#: ../../../CHANGES:221
+msgid "Added better documentation regarding Flask-Mail configuration"
+msgstr ""
+
+#: ../../../CHANGES:222
+msgid "Added ability to configure email subjects"
+msgstr ""
+
+#: ../../../CHANGES:225
+msgid "Version 1.5.0"
+msgstr ""
+
+#: ../../../CHANGES:227
+msgid "Released October 11th 2012"
+msgstr ""
+
+#: ../../../CHANGES:229
+msgid ""
+"Major release. Upgrading from previous versions will require a bit of "
+"work to accomodate API changes. See documentation for a list of new "
+"features and for help on how to upgrade."
+msgstr ""
+
+#: ../../../CHANGES:234
+msgid "Version 1.2.3"
+msgstr ""
+
+#: ../../../CHANGES:236
+msgid "Released June 12th 2012"
+msgstr ""
+
+#: ../../../CHANGES:238
+msgid "Fixed a bug in the RoleMixin eq/ne functions"
+msgstr ""
+
+#: ../../../CHANGES:241
+msgid "Version 1.2.2"
+msgstr ""
+
+#: ../../../CHANGES:243
+msgid "Released April 27th 2012"
+msgstr ""
+
+#: ../../../CHANGES:245
+msgid ""
+"Fixed bug where `roles_required` and `roles_accepted` did not pass the "
+"next argument to the login view"
+msgstr ""
+
+#: ../../../CHANGES:249
+msgid "Version 1.2.1"
+msgstr ""
+
+#: ../../../CHANGES:251
+msgid "Released March 28th 2012"
+msgstr ""
+
+#: ../../../CHANGES:253
+msgid "Added optional user model mixin parameter for datastores"
+msgstr ""
+
+#: ../../../CHANGES:254
+msgid "Added CreateRoleCommand to available Flask-Script commands"
+msgstr ""
+
+#: ../../../CHANGES:257
+msgid "Version 1.2.0"
+msgstr ""
+
+#: ../../../CHANGES:259
+msgid "Released March 12th 2012"
+msgstr ""
+
+#: ../../../CHANGES:261
+msgid ""
+"Added configuration option `SECURITY_FLASH_MESSAGES` which can be set to "
+"a boolean value to specify if Flask-Security should flash messages or "
+"not."
+msgstr ""
+
+#: ../../../CHANGES:265
+msgid "Version 1.1.0"
+msgstr ""
+
+#: ../../../CHANGES:267
+msgid "Initial release"
+msgstr ""
+

--- a/docs/locale/zh-CN/LC_MESSAGES/configuration.po
+++ b/docs/locale/zh-CN/LC_MESSAGES/configuration.po
@@ -1,0 +1,796 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2012, Matt Wright
+# This file is distributed under the same license as the Flask-Security
+# package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Flask-Security 1.7.5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-03-28 10:58+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.4.0\n"
+
+#: ../../configuration.rst:2
+msgid "Configuration"
+msgstr ""
+
+#: ../../configuration.rst:4
+msgid "The following configuration values are used by Flask-Security:"
+msgstr ""
+
+#: ../../configuration.rst:7
+msgid "Core"
+msgstr ""
+
+#: ../../configuration.rst:12
+msgid "``SECURITY_BLUEPRINT_NAME``"
+msgstr ""
+
+#: ../../configuration.rst:12
+msgid ""
+"Specifies the name for the Flask-Security blueprint. Defaults to "
+"``security``."
+msgstr ""
+
+#: ../../configuration.rst:15
+msgid "``SECURITY_URL_PREFIX``"
+msgstr ""
+
+#: ../../configuration.rst:15
+msgid ""
+"Specifies the URL prefix for the Flask-Security blueprint. Defaults to "
+"``None``."
+msgstr ""
+
+#: ../../configuration.rst:18
+msgid "``SECURITY_SUBDOMAIN``"
+msgstr ""
+
+#: ../../configuration.rst:18
+msgid ""
+"Specifies the subdomain for the Flask-Security blueprint. Defaults to "
+"``None``."
+msgstr ""
+
+#: ../../configuration.rst:21
+msgid "``SECURITY_FLASH_MESSAGES``"
+msgstr ""
+
+#: ../../configuration.rst:21
+msgid ""
+"Specifies whether or not to flash messages during security procedures. "
+"Defaults to ``True``."
+msgstr ""
+
+#: ../../configuration.rst:24
+msgid "``SECURITY_PASSWORD_HASH``"
+msgstr ""
+
+#: ../../configuration.rst:24
+msgid ""
+"Specifies the password hash algorithm to use when encrypting and "
+"decrypting passwords. Recommended values for production systems are "
+"``bcrypt``, ``sha512_crypt``, or ``pbkdf2_sha512``. Defaults to "
+"``plaintext``."
+msgstr ""
+
+#: ../../configuration.rst:30
+msgid "``SECURITY_PASSWORD_SALT``"
+msgstr ""
+
+#: ../../configuration.rst:30
+msgid ""
+"Specifies the HMAC salt. This is only used if the password hash type is "
+"set to something other than plain text. Defaults to ``None``."
+msgstr ""
+
+#: ../../configuration.rst:34
+msgid "``SECURITY_EMAIL_SENDER``"
+msgstr ""
+
+#: ../../configuration.rst:34
+msgid ""
+"Specifies the email address to send emails as. Defaults to ``no-"
+"reply@localhost``."
+msgstr ""
+
+#: ../../configuration.rst:37
+msgid "``SECURITY_TOKEN_AUTHENTICATION_KEY``"
+msgstr ""
+
+#: ../../configuration.rst:37
+msgid ""
+"Specifies the query string parameter to read when using token "
+"authentication. Defaults to ``auth_token``."
+msgstr ""
+
+#: ../../configuration.rst:40
+msgid "``SECURITY_TOKEN_AUTHENTICATION_HEADER``"
+msgstr ""
+
+#: ../../configuration.rst:40
+msgid ""
+"Specifies the HTTP header to read when using token authentication. "
+"Defaults to ``Authentication-Token``."
+msgstr ""
+
+#: ../../configuration.rst:43
+msgid "``SECURITY_TOKEN_MAX_AGE``"
+msgstr ""
+
+#: ../../configuration.rst:43
+msgid ""
+"Specifies the number of seconds before an authentication token expires. "
+"Defaults to None, meaning the token never expires."
+msgstr ""
+
+#: ../../configuration.rst:47
+msgid "``SECURITY_DEFAULT_HTTP_AUTH_REALM``"
+msgstr ""
+
+#: ../../configuration.rst:47
+msgid ""
+"Specifies the default authentication realm when using basic HTTP auth. "
+"Defaults to ``Login Required``"
+msgstr ""
+
+#: ../../configuration.rst:54
+msgid "URLs and Views"
+msgstr ""
+
+#: ../../configuration.rst:59
+msgid "``SECURITY_LOGIN_URL``"
+msgstr ""
+
+#: ../../configuration.rst:59
+msgid "Specifies the login URL. Defaults to ``/login``."
+msgstr ""
+
+#: ../../configuration.rst:60
+msgid "``SECURITY_LOGOUT_URL``"
+msgstr ""
+
+#: ../../configuration.rst:60
+msgid "Specifies the logout URL. Defaults to ``/logout``."
+msgstr ""
+
+#: ../../configuration.rst:62
+msgid "``SECURITY_REGISTER_URL``"
+msgstr ""
+
+#: ../../configuration.rst:62
+msgid "Specifies the register URL. Defaults to ``/register``."
+msgstr ""
+
+#: ../../configuration.rst:64
+msgid "``SECURITY_RESET_URL``"
+msgstr ""
+
+#: ../../configuration.rst:64
+msgid "Specifies the password reset URL. Defaults to ``/reset``."
+msgstr ""
+
+#: ../../configuration.rst:66
+msgid "``SECURITY_CHANGE_URL``"
+msgstr ""
+
+#: ../../configuration.rst:66
+msgid "Specifies the password change URL. Defaults to ``/change``."
+msgstr ""
+
+#: ../../configuration.rst:68
+msgid "``SECURITY_CONFIRM_URL``"
+msgstr ""
+
+#: ../../configuration.rst:68
+msgid "Specifies the email confirmation URL. Defaults to ``/confirm``."
+msgstr ""
+
+#: ../../configuration.rst:70
+msgid "``SECURITY_POST_LOGIN_VIEW``"
+msgstr ""
+
+#: ../../configuration.rst:70
+msgid ""
+"Specifies the default view to redirect to after a user logs in. This "
+"value can be set to a URL or an endpoint name. Defaults to ``/``."
+msgstr ""
+
+#: ../../configuration.rst:73
+msgid "``SECURITY_POST_LOGOUT_VIEW``"
+msgstr ""
+
+#: ../../configuration.rst:73
+msgid ""
+"Specifies the default view to redirect to after a user logs out. This "
+"value can be set to a URL or an endpoint name. Defaults to ``/``."
+msgstr ""
+
+#: ../../configuration.rst:76
+msgid "``SECURITY_CONFIRM_ERROR_VIEW``"
+msgstr ""
+
+#: ../../configuration.rst:76
+msgid ""
+"Specifies the view to redirect to if a confirmation error occurs. This "
+"value can be set to a URL or an endpoint name. If this value is ``None``,"
+" the user is presented the default view to resend a confirmation link. "
+"Defaults to ``None``."
+msgstr ""
+
+#: ../../configuration.rst:82
+msgid "``SECURITY_POST_REGISTER_VIEW``"
+msgstr ""
+
+#: ../../configuration.rst:82
+msgid ""
+"Specifies the view to redirect to after a user successfully registers. "
+"This value can be set to a URL or an endpoint name. If this value is "
+"``None``, the user is redirected to the value of "
+"``SECURITY_POST_LOGIN_VIEW``. Defaults to ``None``."
+msgstr ""
+
+#: ../../configuration.rst:88
+msgid "``SECURITY_POST_CONFIRM_VIEW``"
+msgstr ""
+
+#: ../../configuration.rst:88
+msgid ""
+"Specifies the view to redirect to after a user successfully confirms "
+"their email. This value can be set to a URL or an endpoint name. If this "
+"value is ``None``, the user is redirected  to the value of "
+"``SECURITY_POST_LOGIN_VIEW``. Defaults to ``None``."
+msgstr ""
+
+#: ../../configuration.rst:94
+msgid "``SECURITY_POST_RESET_VIEW``"
+msgstr ""
+
+#: ../../configuration.rst:94
+msgid ""
+"Specifies the view to redirect to after a user successfully resets their "
+"password. This value can be set to a URL or an endpoint name. If this "
+"value is ``None``, the user is redirected  to the value of "
+"``SECURITY_POST_LOGIN_VIEW``. Defaults to ``None``."
+msgstr ""
+
+#: ../../configuration.rst:100
+msgid "``SECURITY_POST_CHANGE_VIEW``"
+msgstr ""
+
+#: ../../configuration.rst:100
+msgid ""
+"Specifies the view to redirect to after a user successfully changes their"
+" password. This value can be set to a URL or an endpoint name. If this "
+"value is ``None``, the user is redirected  to the value of "
+"``SECURITY_POST_LOGIN_VIEW``. Defaults to ``None``."
+msgstr ""
+
+#: ../../configuration.rst:106
+msgid "``SECURITY_UNAUTHORIZED_VIEW``"
+msgstr ""
+
+#: ../../configuration.rst:106
+msgid ""
+"Specifies the view to redirect to if a user attempts to access a "
+"URL/endpoint that they do not have permission to access. If this value is"
+" ``None``, the user is presented with a default HTTP 403 response. "
+"Defaults to ``None``."
+msgstr ""
+
+#: ../../configuration.rst:115
+msgid "Template Paths"
+msgstr ""
+
+#: ../../configuration.rst:120
+msgid "``SECURITY_FORGOT_PASSWORD_TEMPLATE``"
+msgstr ""
+
+#: ../../configuration.rst:120
+msgid ""
+"Specifies the path to the template for the forgot password page. Defaults"
+" to ``security/forgot_password.html``."
+msgstr ""
+
+#: ../../configuration.rst:123
+msgid "``SECURITY_LOGIN_USER_TEMPLATE``"
+msgstr ""
+
+#: ../../configuration.rst:123
+msgid ""
+"Specifies the path to the template for the user login page. Defaults to "
+"``security/login_user.html``."
+msgstr ""
+
+#: ../../configuration.rst:126
+msgid "``SECURITY_REGISTER_USER_TEMPLATE``"
+msgstr ""
+
+#: ../../configuration.rst:126
+msgid ""
+"Specifies the path to the template for the user registration page. "
+"Defaults to ``security/register_user.html``."
+msgstr ""
+
+#: ../../configuration.rst:129
+msgid "``SECURITY_RESET_PASSWORD_TEMPLATE``"
+msgstr ""
+
+#: ../../configuration.rst:129
+msgid ""
+"Specifies the path to the template for the reset password page. Defaults "
+"to ``security/reset_password.html``."
+msgstr ""
+
+#: ../../configuration.rst:132
+msgid "``SECURITY_CHANGE_PASSWORD_TEMPLATE``"
+msgstr ""
+
+#: ../../configuration.rst:132
+msgid ""
+"Specifies the path to the template for the change password page. Defaults"
+" to ``security/change_password.html``."
+msgstr ""
+
+#: ../../configuration.rst:135
+msgid "``SECURITY_SEND_CONFIRMATION_TEMPLATE``"
+msgstr ""
+
+#: ../../configuration.rst:135
+msgid ""
+"Specifies the path to the template for the resend confirmation "
+"instructions page. Defaults to ``security/send_confirmation.html``."
+msgstr ""
+
+#: ../../configuration.rst:139
+msgid "``SECURITY_SEND_LOGIN_TEMPLATE``"
+msgstr ""
+
+#: ../../configuration.rst:139
+msgid ""
+"Specifies the path to the template for the send login instructions page "
+"for passwordless logins. Defaults to ``security/send_login.html``."
+msgstr ""
+
+#: ../../configuration.rst:147
+msgid "Feature Flags"
+msgstr ""
+
+#: ../../configuration.rst:152
+msgid "``SECURITY_CONFIRMABLE``"
+msgstr ""
+
+#: ../../configuration.rst:152
+msgid ""
+"Specifies if users are required to confirm their email address when "
+"registering a new account. If this value is `True`, Flask-Security "
+"creates an endpoint to handle confirmations and requests to resend "
+"confirmation instructions. The URL for this endpoint is specified by the "
+"``SECURITY_CONFIRM_URL`` configuration option. Defaults to ``False``."
+msgstr ""
+
+#: ../../configuration.rst:159
+msgid "``SECURITY_REGISTERABLE``"
+msgstr ""
+
+#: ../../configuration.rst:159
+msgid ""
+"Specifies if Flask-Security should create a user registration endpoint. "
+"The URL for this endpoint is specified by the ``SECURITY_REGISTER_URL`` "
+"configuration option. Defaults to ``False``."
+msgstr ""
+
+#: ../../configuration.rst:163
+msgid "``SECURITY_RECOVERABLE``"
+msgstr ""
+
+#: ../../configuration.rst:163
+msgid ""
+"Specifies if Flask-Security should create a password reset/recover "
+"endpoint. The URL for this endpoint is specified by the "
+"``SECURITY_RESET_URL`` configuration option. Defaults to ``False``."
+msgstr ""
+
+#: ../../configuration.rst:167
+msgid "``SECURITY_TRACKABLE``"
+msgstr ""
+
+#: ../../configuration.rst:167
+msgid ""
+"Specifies if Flask-Security should track basic user login statistics. If "
+"set to ``True``, ensure your models have the required fields/attributes. "
+"Be sure to use `ProxyFix <http://flask.pocoo.org/docs/0.10/deploying"
+"/wsgi-standalone/#proxy-setups>` if you are using a proxy. Defaults to "
+"``False``"
+msgstr ""
+
+#: ../../configuration.rst:172
+msgid "``SECURITY_PASSWORDLESS``"
+msgstr ""
+
+#: ../../configuration.rst:172
+msgid ""
+"Specifies if Flask-Security should enable the passwordless login feature."
+" If set to ``True``, users are not required to enter a password to login "
+"but are sent an email with a login link. This feature is experimental and"
+" should be used with caution. Defaults to ``False``."
+msgstr ""
+
+#: ../../configuration.rst:178
+msgid "``SECURITY_CHANGEABLE``"
+msgstr ""
+
+#: ../../configuration.rst:178
+msgid ""
+"Specifies if Flask-Security should enable the change password endpoint. "
+"The URL for this endpoint is specified by the ``SECURITY_CHANGE_URL`` "
+"configuration option. Defaults to ``False``."
+msgstr ""
+
+#: ../../configuration.rst:185
+msgid "Email"
+msgstr ""
+
+#: ../../configuration.rst:190
+msgid "``SECURITY_EMAIL_SUBJECT_REGISTER``"
+msgstr ""
+
+#: ../../configuration.rst:190
+msgid "Sets the subject for the confirmation email. Defaults to ``Welcome``"
+msgstr ""
+
+#: ../../configuration.rst:193
+msgid "``SECURITY_EMAIL_SUBJECT_PASSWORDLESS``"
+msgstr ""
+
+#: ../../configuration.rst:193
+msgid ""
+"Sets the subject for the passwordless feature. Defaults to ``Login "
+"instructions``"
+msgstr ""
+
+#: ../../configuration.rst:196
+msgid "``SECURITY_EMAIL_SUBJECT_PASSWORD_NOTICE``"
+msgstr ""
+
+#: ../../configuration.rst:196
+msgid ""
+"Sets subject for the password notice. Defaults to ``Your password has "
+"been reset``"
+msgstr ""
+
+#: ../../configuration.rst:199
+msgid "``SECURITY_EMAIL_SUBJECT_PASSWORD_RESET``"
+msgstr ""
+
+#: ../../configuration.rst:199
+msgid ""
+"Sets the subject for the password reset email. Defaults to ``Password "
+"reset instructions``"
+msgstr ""
+
+#: ../../configuration.rst:203
+msgid "``SECURITY_EMAIL_SUBJECT_PASSWORD_CHANGE_NOTICE``"
+msgstr ""
+
+#: ../../configuration.rst:203
+msgid ""
+"Sets the subject for the password change notice. Defaults to ``Your "
+"password has been changed``"
+msgstr ""
+
+#: ../../configuration.rst:207
+msgid "``SECURITY_EMAIL_SUBJECT_CONFIRM``"
+msgstr ""
+
+#: ../../configuration.rst:207
+msgid ""
+"Sets the subject for the email confirmation message. Defaults to ``Please"
+" confirm your email``"
+msgstr ""
+
+#: ../../configuration.rst:211
+msgid "``SECURITY_EMAIL_PLAINTEXT``"
+msgstr ""
+
+#: ../../configuration.rst:211
+msgid ""
+"Enable email to be sent as plaintext (Using *.txt template). Defaults "
+"``True``"
+msgstr ""
+
+#: ../../configuration.rst:214
+msgid "``SECURITY_EMAIL_HTML``"
+msgstr ""
+
+#: ../../configuration.rst:214
+msgid ""
+"Enable email to be sent as plaintext (Using *.html template). Defaults "
+"``True``"
+msgstr ""
+
+#: ../../configuration.rst:220
+msgid "Miscellaneous"
+msgstr ""
+
+#: ../../configuration.rst:225
+msgid "``SECURITY_USER_IDENTITY_ATTRIBUTES``"
+msgstr ""
+
+#: ../../configuration.rst:225
+msgid ""
+"Specifies which attributes of the user object can be used for login. "
+"Defaults to ``['email']``."
+msgstr ""
+
+#: ../../configuration.rst:228
+msgid "``SECURITY_SEND_REGISTER_EMAIL``"
+msgstr ""
+
+#: ../../configuration.rst:228
+msgid "Specifies whether registration email is sent. Defaults to ``True``."
+msgstr ""
+
+#: ../../configuration.rst:231
+msgid "``SECURITY_SEND_PASSWORD_CHANGE_EMAIL``"
+msgstr ""
+
+#: ../../configuration.rst:231
+msgid "Specifies whether password change email is sent. Defaults to ``True``."
+msgstr ""
+
+#: ../../configuration.rst:234
+msgid "``SECURITY_SEND_PASSWORD_RESET_NOTICE_EMAIL``"
+msgstr ""
+
+#: ../../configuration.rst:234
+msgid ""
+"Specifies whether password reset notice email is sent. Defaults to "
+"``True``."
+msgstr ""
+
+#: ../../configuration.rst:238
+msgid "``SECURITY_CONFIRM_EMAIL_WITHIN``"
+msgstr ""
+
+#: ../../configuration.rst:238
+msgid ""
+"Specifies the amount of time a user has before their confirmation link "
+"expires. Always pluralized the time unit for this value. Defaults to ``5 "
+"days``."
+msgstr ""
+
+#: ../../configuration.rst:243
+msgid "``SECURITY_RESET_PASSWORD_WITHIN``"
+msgstr ""
+
+#: ../../configuration.rst:243
+msgid ""
+"Specifies the amount of time a user has before their password reset link "
+"expires. Always pluralized the time unit for this value. Defaults to ``5 "
+"days``."
+msgstr ""
+
+#: ../../configuration.rst:248
+msgid "``SECURITY_LOGIN_WITHIN``"
+msgstr ""
+
+#: ../../configuration.rst:248
+msgid ""
+"Specifies the amount of time a user has before a login link expires. This"
+" is only used when the passwordless login feature is enabled. Always "
+"pluralized the time unit for this value. Defaults to ``1 days``."
+msgstr ""
+
+#: ../../configuration.rst:255
+msgid "``SECURITY_LOGIN_WITHOUT_CONFIRMATION``"
+msgstr ""
+
+#: ../../configuration.rst:255
+msgid ""
+"Specifies if a user may login before confirming their email when the "
+"value of ``SECURITY_CONFIRMABLE`` is set to ``True``. Defaults to "
+"``False``."
+msgstr ""
+
+#: ../../configuration.rst:260
+msgid "``SECURITY_CONFIRM_SALT``"
+msgstr ""
+
+#: ../../configuration.rst:260
+msgid ""
+"Specifies the salt value when generating confirmation links/tokens. "
+"Defaults to ``confirm-salt``."
+msgstr ""
+
+#: ../../configuration.rst:264
+msgid "``SECURITY_RESET_SALT``"
+msgstr ""
+
+#: ../../configuration.rst:264
+msgid ""
+"Specifies the salt value when generating password reset links/tokens. "
+"Defaults to ``reset-salt``."
+msgstr ""
+
+#: ../../configuration.rst:268
+msgid "``SECURITY_LOGIN_SALT``"
+msgstr ""
+
+#: ../../configuration.rst:268
+msgid ""
+"Specifies the salt value when generating login links/tokens. Defaults to "
+"``login-salt``."
+msgstr ""
+
+#: ../../configuration.rst:271
+msgid "``SECURITY_REMEMBER_SALT``"
+msgstr ""
+
+#: ../../configuration.rst:271
+msgid ""
+"Specifies the salt value when generating remember tokens. Remember tokens"
+" are used instead of user ID's as it is more secure. Defaults to "
+"``remember-salt``."
+msgstr ""
+
+#: ../../configuration.rst:277
+msgid "``SECURITY_DEFAULT_REMEMBER_ME``"
+msgstr ""
+
+#: ../../configuration.rst:277
+msgid ""
+"Specifies the default \"remember me\" value used when logging in a user. "
+"Defaults to ``False``."
+msgstr ""
+
+#: ../../configuration.rst:283
+msgid "Messages"
+msgstr ""
+
+#: ../../configuration.rst:285
+msgid ""
+"The following are the messages Flask-Security uses.  They are tuples; the"
+" first element is the message and the second element is the error level."
+msgstr ""
+
+#: ../../configuration.rst:288
+msgid "The default messages and error levels can be found in ``core.py``."
+msgstr ""
+
+#: ../../configuration.rst:290
+msgid "``SECURITY_MSG_ALREADY_CONFIRMED``"
+msgstr ""
+
+#: ../../configuration.rst:291
+msgid "``SECURITY_MSG_CONFIRMATION_EXPIRED``"
+msgstr ""
+
+#: ../../configuration.rst:292
+msgid "``SECURITY_MSG_CONFIRMATION_REQUEST``"
+msgstr ""
+
+#: ../../configuration.rst:293
+msgid "``SECURITY_MSG_CONFIRMATION_REQUIRED``"
+msgstr ""
+
+#: ../../configuration.rst:294
+msgid "``SECURITY_MSG_CONFIRM_REGISTRATION``"
+msgstr ""
+
+#: ../../configuration.rst:295
+msgid "``SECURITY_MSG_DISABLED_ACCOUNT``"
+msgstr ""
+
+#: ../../configuration.rst:296
+msgid "``SECURITY_MSG_EMAIL_ALREADY_ASSOCIATED``"
+msgstr ""
+
+#: ../../configuration.rst:297
+msgid "``SECURITY_MSG_EMAIL_CONFIRMED``"
+msgstr ""
+
+#: ../../configuration.rst:298
+msgid "``SECURITY_MSG_EMAIL_NOT_PROVIDED``"
+msgstr ""
+
+#: ../../configuration.rst:299
+msgid "``SECURITY_MSG_INVALID_CONFIRMATION_TOKEN``"
+msgstr ""
+
+#: ../../configuration.rst:300
+msgid "``SECURITY_MSG_INVALID_EMAIL_ADDRESS``"
+msgstr ""
+
+#: ../../configuration.rst:301
+msgid "``SECURITY_MSG_INVALID_LOGIN_TOKEN``"
+msgstr ""
+
+#: ../../configuration.rst:302
+msgid "``SECURITY_MSG_INVALID_PASSWORD``"
+msgstr ""
+
+#: ../../configuration.rst:303
+msgid "``SECURITY_MSG_INVALID_REDIRECT``"
+msgstr ""
+
+#: ../../configuration.rst:304
+msgid "``SECURITY_MSG_INVALID_RESET_PASSWORD_TOKEN``"
+msgstr ""
+
+#: ../../configuration.rst:305
+msgid "``SECURITY_MSG_LOGIN``"
+msgstr ""
+
+#: ../../configuration.rst:306
+msgid "``SECURITY_MSG_LOGIN_EMAIL_SENT``"
+msgstr ""
+
+#: ../../configuration.rst:307
+msgid "``SECURITY_MSG_LOGIN_EXPIRED``"
+msgstr ""
+
+#: ../../configuration.rst:308
+msgid "``SECURITY_MSG_PASSWORDLESS_LOGIN_SUCCESSFUL``"
+msgstr ""
+
+#: ../../configuration.rst:309
+msgid "``SECURITY_MSG_PASSWORD_CHANGE``"
+msgstr ""
+
+#: ../../configuration.rst:310
+msgid "``SECURITY_MSG_PASSWORD_INVALID_LENGTH``"
+msgstr ""
+
+#: ../../configuration.rst:311
+msgid "``SECURITY_MSG_PASSWORD_IS_THE_SAME``"
+msgstr ""
+
+#: ../../configuration.rst:312
+msgid "``SECURITY_MSG_PASSWORD_MISMATCH``"
+msgstr ""
+
+#: ../../configuration.rst:313
+msgid "``SECURITY_MSG_PASSWORD_NOT_PROVIDED``"
+msgstr ""
+
+#: ../../configuration.rst:314
+msgid "``SECURITY_MSG_PASSWORD_NOT_SET``"
+msgstr ""
+
+#: ../../configuration.rst:315
+msgid "``SECURITY_MSG_PASSWORD_RESET``"
+msgstr ""
+
+#: ../../configuration.rst:316
+msgid "``SECURITY_MSG_PASSWORD_RESET_EXPIRED``"
+msgstr ""
+
+#: ../../configuration.rst:317
+msgid "``SECURITY_MSG_PASSWORD_RESET_REQUEST``"
+msgstr ""
+
+#: ../../configuration.rst:318
+msgid "``SECURITY_MSG_REFRESH``"
+msgstr ""
+
+#: ../../configuration.rst:319
+msgid "``SECURITY_MSG_RETYPE_PASSWORD_MISMATCH``"
+msgstr ""
+
+#: ../../configuration.rst:320
+msgid "``SECURITY_MSG_UNAUTHORIZED``"
+msgstr ""
+
+#: ../../configuration.rst:321
+msgid "``SECURITY_MSG_USER_DOES_NOT_EXIST``"
+msgstr ""
+

--- a/docs/locale/zh-CN/LC_MESSAGES/configuration.po
+++ b/docs/locale/zh-CN/LC_MESSAGES/configuration.po
@@ -4,793 +4,840 @@
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 1.7.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-28 10:58+0800\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"POT-Creation-Date: 2017-03-28 15:06+0800\n"
+"PO-Revision-Date: 2017-03-28 15:11+0800\n"
+"Last-Translator: \n"
+"Language: zh_CN\n"
+"Language-Team: \n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.4.0\n"
+"X-Generator: Poedit 1.8.6\n"
 
 #: ../../configuration.rst:2
 msgid "Configuration"
-msgstr ""
+msgstr "配置"
 
 #: ../../configuration.rst:4
 msgid "The following configuration values are used by Flask-Security:"
-msgstr ""
+msgstr "下面是 Flask-Security 所使用的配置参数:"
 
 #: ../../configuration.rst:7
 msgid "Core"
-msgstr ""
+msgstr "核心"
 
 #: ../../configuration.rst:12
 msgid "``SECURITY_BLUEPRINT_NAME``"
-msgstr ""
+msgstr "``SECURITY_BLUEPRINT_NAME``"
 
 #: ../../configuration.rst:12
 msgid ""
-"Specifies the name for the Flask-Security blueprint. Defaults to "
-"``security``."
-msgstr ""
+"Specifies the name for the Flask-Security blueprint. Defaults to ``security``."
+msgstr "为 Flask-Security 指定蓝图名称. 默认为 ``security``."
 
 #: ../../configuration.rst:15
 msgid "``SECURITY_URL_PREFIX``"
-msgstr ""
+msgstr "``SECURITY_URL_PREFIX``"
 
 #: ../../configuration.rst:15
 msgid ""
 "Specifies the URL prefix for the Flask-Security blueprint. Defaults to "
 "``None``."
-msgstr ""
+msgstr " 为 Flask-Security 指定蓝图 URL 前缀. 默认为 ``None``."
 
 #: ../../configuration.rst:18
 msgid "``SECURITY_SUBDOMAIN``"
-msgstr ""
+msgstr "``SECURITY_SUBDOMAIN``"
 
 #: ../../configuration.rst:18
 msgid ""
-"Specifies the subdomain for the Flask-Security blueprint. Defaults to "
-"``None``."
-msgstr ""
+"Specifies the subdomain for the Flask-Security blueprint. Defaults to ``None``."
+msgstr "为 Flask-Security 指定蓝图子域名. 默认为 ``None``."
 
 #: ../../configuration.rst:21
 msgid "``SECURITY_FLASH_MESSAGES``"
-msgstr ""
+msgstr "``SECURITY_FLASH_MESSAGES``"
 
 #: ../../configuration.rst:21
 msgid ""
 "Specifies whether or not to flash messages during security procedures. "
 "Defaults to ``True``."
-msgstr ""
+msgstr "指定安全验证过程中是否闪现(flash)消息. 默认为 ``True``."
 
 #: ../../configuration.rst:24
 msgid "``SECURITY_PASSWORD_HASH``"
-msgstr ""
+msgstr "``SECURITY_PASSWORD_HASH``"
 
 #: ../../configuration.rst:24
 msgid ""
-"Specifies the password hash algorithm to use when encrypting and "
-"decrypting passwords. Recommended values for production systems are "
-"``bcrypt``, ``sha512_crypt``, or ``pbkdf2_sha512``. Defaults to "
-"``plaintext``."
+"Specifies the password hash algorithm to use when encrypting and decrypting "
+"passwords. Recommended values for production systems are ``bcrypt``, "
+"``sha512_crypt``, or ``pbkdf2_sha512``. Defaults to ``plaintext``."
 msgstr ""
+"指定密码加解密所用的hash算法. 推荐在生产环境中使用 ``bcrypt``, "
+"``sha512_crypt``,  ``pbkdf2_sha512``. 默认为 ``plaintext``."
 
 #: ../../configuration.rst:30
 msgid "``SECURITY_PASSWORD_SALT``"
-msgstr ""
+msgstr "``SECURITY_PASSWORD_SALT``"
 
 #: ../../configuration.rst:30
 msgid ""
-"Specifies the HMAC salt. This is only used if the password hash type is "
-"set to something other than plain text. Defaults to ``None``."
+"Specifies the HMAC salt. This is only used if the password hash type is set to "
+"something other than plain text. Defaults to ``None``."
 msgstr ""
+"指定 HMAC 盐. 仅在密码hash类型设置为纯文本以外的类型时生效. 默认为 ``None``."
 
 #: ../../configuration.rst:34
 msgid "``SECURITY_EMAIL_SENDER``"
-msgstr ""
+msgstr "``SECURITY_EMAIL_SENDER``"
 
 #: ../../configuration.rst:34
 msgid ""
 "Specifies the email address to send emails as. Defaults to ``no-"
 "reply@localhost``."
-msgstr ""
+msgstr "指定发送邮件的邮箱地址. 默认为 ``no-reply@localhost``."
 
 #: ../../configuration.rst:37
 msgid "``SECURITY_TOKEN_AUTHENTICATION_KEY``"
-msgstr ""
+msgstr "``SECURITY_TOKEN_AUTHENTICATION_KEY``"
 
 #: ../../configuration.rst:37
 msgid ""
-"Specifies the query string parameter to read when using token "
-"authentication. Defaults to ``auth_token``."
+"Specifies the query string parameter to read when using token authentication. "
+"Defaults to ``auth_token``."
 msgstr ""
+"指定当使用令牌验证时需要读取的查询字符串参数 ( query string parameter ). 默认"
+"为 ``auth_token``."
 
 #: ../../configuration.rst:40
 msgid "``SECURITY_TOKEN_AUTHENTICATION_HEADER``"
-msgstr ""
+msgstr "``SECURITY_TOKEN_AUTHENTICATION_HEADER``"
 
 #: ../../configuration.rst:40
 msgid ""
-"Specifies the HTTP header to read when using token authentication. "
-"Defaults to ``Authentication-Token``."
-msgstr ""
+"Specifies the HTTP header to read when using token authentication. Defaults to "
+"``Authentication-Token``."
+msgstr "指定当使用令牌验证时需要读取的HTTP头. 默认为 ``Authentication-Token``."
 
 #: ../../configuration.rst:43
 msgid "``SECURITY_TOKEN_MAX_AGE``"
-msgstr ""
+msgstr "``SECURITY_TOKEN_MAX_AGE``"
 
 #: ../../configuration.rst:43
 msgid ""
 "Specifies the number of seconds before an authentication token expires. "
 "Defaults to None, meaning the token never expires."
-msgstr ""
+msgstr "指定验证令牌过期时间(秒). 默认为 ``None``,表示永不过期."
 
 #: ../../configuration.rst:47
 msgid "``SECURITY_DEFAULT_HTTP_AUTH_REALM``"
-msgstr ""
+msgstr "``SECURITY_DEFAULT_HTTP_AUTH_REALM``"
 
 #: ../../configuration.rst:47
 msgid ""
 "Specifies the default authentication realm when using basic HTTP auth. "
 "Defaults to ``Login Required``"
 msgstr ""
+"指定当使用 HTTP 验证时的默认身份验证域 ( authentication realm ). 默认为 "
+"``Login Required``."
 
 #: ../../configuration.rst:54
 msgid "URLs and Views"
-msgstr ""
+msgstr "URLs 和视图"
 
 #: ../../configuration.rst:59
 msgid "``SECURITY_LOGIN_URL``"
-msgstr ""
+msgstr "``SECURITY_LOGIN_URL``"
 
 #: ../../configuration.rst:59
 msgid "Specifies the login URL. Defaults to ``/login``."
-msgstr ""
+msgstr "指定登录 URL. 默认为 ``/login``."
 
 #: ../../configuration.rst:60
 msgid "``SECURITY_LOGOUT_URL``"
-msgstr ""
+msgstr "``SECURITY_LOGOUT_URL``"
 
 #: ../../configuration.rst:60
 msgid "Specifies the logout URL. Defaults to ``/logout``."
-msgstr ""
+msgstr "指定登出 URL. 默认为 ``/logout``."
 
 #: ../../configuration.rst:62
 msgid "``SECURITY_REGISTER_URL``"
-msgstr ""
+msgstr "``SECURITY_REGISTER_URL``"
 
 #: ../../configuration.rst:62
 msgid "Specifies the register URL. Defaults to ``/register``."
-msgstr ""
+msgstr "指定注册 URL. 默认为 ``/register``."
 
 #: ../../configuration.rst:64
 msgid "``SECURITY_RESET_URL``"
-msgstr ""
+msgstr "``SECURITY_RESET_URL``"
 
 #: ../../configuration.rst:64
 msgid "Specifies the password reset URL. Defaults to ``/reset``."
-msgstr ""
+msgstr "指定密码重置 URL. 默认为 ``/reset``."
 
 #: ../../configuration.rst:66
 msgid "``SECURITY_CHANGE_URL``"
-msgstr ""
+msgstr "``SECURITY_CHANGE_URL``"
 
 #: ../../configuration.rst:66
 msgid "Specifies the password change URL. Defaults to ``/change``."
-msgstr ""
+msgstr "指定修改密码 URL. 默认为 ``/change``."
 
 #: ../../configuration.rst:68
 msgid "``SECURITY_CONFIRM_URL``"
-msgstr ""
+msgstr "``SECURITY_CONFIRM_URL``"
 
 #: ../../configuration.rst:68
 msgid "Specifies the email confirmation URL. Defaults to ``/confirm``."
-msgstr ""
+msgstr "指定邮箱验证 URL. 默认为 ``/confirm``."
 
 #: ../../configuration.rst:70
 msgid "``SECURITY_POST_LOGIN_VIEW``"
-msgstr ""
+msgstr "``SECURITY_POST_LOGIN_VIEW``"
 
 #: ../../configuration.rst:70
 msgid ""
-"Specifies the default view to redirect to after a user logs in. This "
-"value can be set to a URL or an endpoint name. Defaults to ``/``."
+"Specifies the default view to redirect to after a user logs in. This value can "
+"be set to a URL or an endpoint name. Defaults to ``/``."
 msgstr ""
+"指定用户登录后默认跳转页面. 这个值可以被设置为一个URL或端点 ( endpoint ) 名. 默"
+"认为 ``/``."
 
 #: ../../configuration.rst:73
 msgid "``SECURITY_POST_LOGOUT_VIEW``"
-msgstr ""
+msgstr "``SECURITY_POST_LOGOUT_VIEW``"
 
 #: ../../configuration.rst:73
 msgid ""
-"Specifies the default view to redirect to after a user logs out. This "
-"value can be set to a URL or an endpoint name. Defaults to ``/``."
+"Specifies the default view to redirect to after a user logs out. This value "
+"can be set to a URL or an endpoint name. Defaults to ``/``."
 msgstr ""
+"指定用户登出后默认跳转页面. 这个值可以被设置为一个URL或端点 ( endpoint ) 名. 默"
+"认为 ``/``."
 
 #: ../../configuration.rst:76
 msgid "``SECURITY_CONFIRM_ERROR_VIEW``"
-msgstr ""
+msgstr "``SECURITY_CONFIRM_ERROR_VIEW``"
 
 #: ../../configuration.rst:76
 msgid ""
-"Specifies the view to redirect to if a confirmation error occurs. This "
-"value can be set to a URL or an endpoint name. If this value is ``None``,"
-" the user is presented the default view to resend a confirmation link. "
-"Defaults to ``None``."
+"Specifies the view to redirect to if a confirmation error occurs. This value "
+"can be set to a URL or an endpoint name. If this value is ``None``, the user "
+"is presented the default view to resend a confirmation link. Defaults to "
+"``None``."
 msgstr ""
+"指定跳转页面当一个验证错误出现. 这个值可以被设置为一个URL或端点 ( endpoint ) "
+"名.如果值为 ``None``, 一个用于重新发送验证链接的默认界面将呈献给用户,  默认为 "
+"``None``."
 
 #: ../../configuration.rst:82
 msgid "``SECURITY_POST_REGISTER_VIEW``"
-msgstr ""
+msgstr "``SECURITY_POST_REGISTER_VIEW``"
 
 #: ../../configuration.rst:82
 msgid ""
-"Specifies the view to redirect to after a user successfully registers. "
-"This value can be set to a URL or an endpoint name. If this value is "
-"``None``, the user is redirected to the value of "
-"``SECURITY_POST_LOGIN_VIEW``. Defaults to ``None``."
+"Specifies the view to redirect to after a user successfully registers. This "
+"value can be set to a URL or an endpoint name. If this value is ``None``, the "
+"user is redirected to the value of ``SECURITY_POST_LOGIN_VIEW``. Defaults to "
+"``None``."
 msgstr ""
+"指定跳转页面当一个用户成功注册. 这个值可以被设置为一个URL或端点 ( endpoint ) "
+"名.如果值为 ``None``, 用户将跳转到 ``SECURITY_POST_LOGIN_VIEW`` 所设置的值,  默"
+"认为 ``None``."
 
 #: ../../configuration.rst:88
 msgid "``SECURITY_POST_CONFIRM_VIEW``"
-msgstr ""
+msgstr "``SECURITY_POST_CONFIRM_VIEW``"
 
 #: ../../configuration.rst:88
 msgid ""
-"Specifies the view to redirect to after a user successfully confirms "
-"their email. This value can be set to a URL or an endpoint name. If this "
-"value is ``None``, the user is redirected  to the value of "
+"Specifies the view to redirect to after a user successfully confirms their "
+"email. This value can be set to a URL or an endpoint name. If this value is "
+"``None``, the user is redirected  to the value of "
 "``SECURITY_POST_LOGIN_VIEW``. Defaults to ``None``."
 msgstr ""
+"指定跳转页面当一个用户成功验证邮箱. 这个值可以被设置为一个URL或端点 "
+"( endpoint ) 名.如果值为 ``None``, 用户将跳转到 ``SECURITY_POST_LOGIN_VIEW`` 所"
+"设置的值,  默认为 ``None``."
 
 #: ../../configuration.rst:94
 msgid "``SECURITY_POST_RESET_VIEW``"
-msgstr ""
+msgstr "``SECURITY_POST_RESET_VIEW``"
 
 #: ../../configuration.rst:94
 msgid ""
 "Specifies the view to redirect to after a user successfully resets their "
-"password. This value can be set to a URL or an endpoint name. If this "
-"value is ``None``, the user is redirected  to the value of "
+"password. This value can be set to a URL or an endpoint name. If this value is "
+"``None``, the user is redirected  to the value of "
 "``SECURITY_POST_LOGIN_VIEW``. Defaults to ``None``."
 msgstr ""
+"指定跳转页面当一个用户成功重置密码. 这个值可以被设置为一个URL或端点 "
+"( endpoint ) 名.如果值为 ``None``, 用户将跳转到 ``SECURITY_POST_LOGIN_VIEW`` 所"
+"设置的值,  默认为 ``None``."
 
 #: ../../configuration.rst:100
 msgid "``SECURITY_POST_CHANGE_VIEW``"
-msgstr ""
+msgstr "``SECURITY_POST_CHANGE_VIEW``"
 
 #: ../../configuration.rst:100
 msgid ""
-"Specifies the view to redirect to after a user successfully changes their"
-" password. This value can be set to a URL or an endpoint name. If this "
-"value is ``None``, the user is redirected  to the value of "
+"Specifies the view to redirect to after a user successfully changes their "
+"password. This value can be set to a URL or an endpoint name. If this value is "
+"``None``, the user is redirected  to the value of "
 "``SECURITY_POST_LOGIN_VIEW``. Defaults to ``None``."
 msgstr ""
+"指定跳转页面当一个用户成功修改密码. 这个值可以被设置为一个URL或端点 "
+"( endpoint ) 名.如果值为 ``None``, 用户将跳转到 ``SECURITY_POST_LOGIN_VIEW`` 所"
+"设置的值,  默认为 ``None``."
 
 #: ../../configuration.rst:106
 msgid "``SECURITY_UNAUTHORIZED_VIEW``"
-msgstr ""
+msgstr "``SECURITY_UNAUTHORIZED_VIEW``"
 
 #: ../../configuration.rst:106
 msgid ""
-"Specifies the view to redirect to if a user attempts to access a "
-"URL/endpoint that they do not have permission to access. If this value is"
-" ``None``, the user is presented with a default HTTP 403 response. "
-"Defaults to ``None``."
+"Specifies the view to redirect to if a user attempts to access a URL/endpoint "
+"that they do not have permission to access. If this value is ``None``, the "
+"user is presented with a default HTTP 403 response. Defaults to ``None``."
 msgstr ""
+"指定跳转页面当一个用户试图访问其没有权限的URL或端点 ( endpoint ) .如果值为 "
+"``None``, 将提供一个默认的HTTP 403 响应给用户,  默认为 ``None``."
 
 #: ../../configuration.rst:115
 msgid "Template Paths"
-msgstr ""
+msgstr "模板路径"
 
 #: ../../configuration.rst:120
 msgid "``SECURITY_FORGOT_PASSWORD_TEMPLATE``"
-msgstr ""
+msgstr "``SECURITY_FORGOT_PASSWORD_TEMPLATE``"
 
 #: ../../configuration.rst:120
 msgid ""
-"Specifies the path to the template for the forgot password page. Defaults"
-" to ``security/forgot_password.html``."
-msgstr ""
+"Specifies the path to the template for the forgot password page. Defaults to "
+"``security/forgot_password.html``."
+msgstr "指定忘记密码页面模板的路径 . 默认为 ``security/forgot_password.html``."
 
 #: ../../configuration.rst:123
 msgid "``SECURITY_LOGIN_USER_TEMPLATE``"
-msgstr ""
+msgstr "``SECURITY_LOGIN_USER_TEMPLATE``"
 
 #: ../../configuration.rst:123
 msgid ""
 "Specifies the path to the template for the user login page. Defaults to "
 "``security/login_user.html``."
-msgstr ""
+msgstr "指定用户登录页面模板的路径 . 默认为 ``security/login_user.html``."
 
 #: ../../configuration.rst:126
 msgid "``SECURITY_REGISTER_USER_TEMPLATE``"
-msgstr ""
+msgstr "``SECURITY_REGISTER_USER_TEMPLATE``"
 
 #: ../../configuration.rst:126
 msgid ""
-"Specifies the path to the template for the user registration page. "
-"Defaults to ``security/register_user.html``."
-msgstr ""
+"Specifies the path to the template for the user registration page. Defaults to "
+"``security/register_user.html``."
+msgstr "指定用户注册页面模板的路径 . 默认为 ``security/register_user.html``."
 
 #: ../../configuration.rst:129
 msgid "``SECURITY_RESET_PASSWORD_TEMPLATE``"
-msgstr ""
+msgstr "``SECURITY_RESET_PASSWORD_TEMPLATE``"
 
 #: ../../configuration.rst:129
 msgid ""
-"Specifies the path to the template for the reset password page. Defaults "
-"to ``security/reset_password.html``."
-msgstr ""
+"Specifies the path to the template for the reset password page. Defaults to "
+"``security/reset_password.html``."
+msgstr "指定重置密码页面模板的路径 . 默认为 ``security/reset_password.html``."
 
 #: ../../configuration.rst:132
 msgid "``SECURITY_CHANGE_PASSWORD_TEMPLATE``"
-msgstr ""
+msgstr "``SECURITY_CHANGE_PASSWORD_TEMPLATE``"
 
 #: ../../configuration.rst:132
 msgid ""
-"Specifies the path to the template for the change password page. Defaults"
-" to ``security/change_password.html``."
-msgstr ""
+"Specifies the path to the template for the change password page. Defaults to "
+"``security/change_password.html``."
+msgstr "指定修改密码页面模板的路径 . 默认为 ``security/change_password.html``."
 
 #: ../../configuration.rst:135
 msgid "``SECURITY_SEND_CONFIRMATION_TEMPLATE``"
-msgstr ""
+msgstr "``SECURITY_SEND_CONFIRMATION_TEMPLATE``"
 
 #: ../../configuration.rst:135
 msgid ""
-"Specifies the path to the template for the resend confirmation "
-"instructions page. Defaults to ``security/send_confirmation.html``."
+"Specifies the path to the template for the resend confirmation instructions "
+"page. Defaults to ``security/send_confirmation.html``."
 msgstr ""
+"指定重新发送验证指令页面模板的路径 . 默认为 ``security/send_confirmation."
+"html``."
 
 #: ../../configuration.rst:139
 msgid "``SECURITY_SEND_LOGIN_TEMPLATE``"
-msgstr ""
+msgstr "``SECURITY_SEND_LOGIN_TEMPLATE``"
 
 #: ../../configuration.rst:139
 msgid ""
-"Specifies the path to the template for the send login instructions page "
-"for passwordless logins. Defaults to ``security/send_login.html``."
+"Specifies the path to the template for the send login instructions page for "
+"passwordless logins. Defaults to ``security/send_login.html``."
 msgstr ""
+"指定发送无密码登录的登录指令页面模板的路径 . 默认为 ``security/"
+"send_confirmation.html``."
 
 #: ../../configuration.rst:147
 msgid "Feature Flags"
-msgstr ""
+msgstr "特性标记"
 
 #: ../../configuration.rst:152
 msgid "``SECURITY_CONFIRMABLE``"
-msgstr ""
+msgstr "``SECURITY_CONFIRMABLE``"
 
 #: ../../configuration.rst:152
 msgid ""
 "Specifies if users are required to confirm their email address when "
-"registering a new account. If this value is `True`, Flask-Security "
-"creates an endpoint to handle confirmations and requests to resend "
-"confirmation instructions. The URL for this endpoint is specified by the "
+"registering a new account. If this value is `True`, Flask-Security creates an "
+"endpoint to handle confirmations and requests to resend confirmation "
+"instructions. The URL for this endpoint is specified by the "
 "``SECURITY_CONFIRM_URL`` configuration option. Defaults to ``False``."
 msgstr ""
+"指定当用户注册一个新账户时是否需要验证他们的邮箱地址. 如果这个值为 `True`, "
+"Flask-Security 将创建一个端 ( endpoint )点去处理验证和请求重新发送验证指令. 这"
+"个端点的 URL 在  ``SECURITY_CONFIRM_URL`` 参数中指定. 默认为 ``False``."
 
 #: ../../configuration.rst:159
 msgid "``SECURITY_REGISTERABLE``"
-msgstr ""
+msgstr "``SECURITY_REGISTERABLE``"
 
 #: ../../configuration.rst:159
 msgid ""
-"Specifies if Flask-Security should create a user registration endpoint. "
-"The URL for this endpoint is specified by the ``SECURITY_REGISTER_URL`` "
+"Specifies if Flask-Security should create a user registration endpoint. The "
+"URL for this endpoint is specified by the ``SECURITY_REGISTER_URL`` "
 "configuration option. Defaults to ``False``."
 msgstr ""
+"指定 Flask-Security 是否创建用户注册端点 ( endpoint ). 这个端点的 URL 在  "
+"``SECURITY_REGISTER_URL`` 参数中指定. 默认为 ``False``."
 
 #: ../../configuration.rst:163
 msgid "``SECURITY_RECOVERABLE``"
-msgstr ""
+msgstr "``SECURITY_RECOVERABLE``"
 
 #: ../../configuration.rst:163
 msgid ""
-"Specifies if Flask-Security should create a password reset/recover "
-"endpoint. The URL for this endpoint is specified by the "
-"``SECURITY_RESET_URL`` configuration option. Defaults to ``False``."
+"Specifies if Flask-Security should create a password reset/recover endpoint. "
+"The URL for this endpoint is specified by the ``SECURITY_RESET_URL`` "
+"configuration option. Defaults to ``False``."
 msgstr ""
+"指定 Flask-Security 是否创建用户重置/恢复密码端点 ( endpoint ). 这个端点的 URL "
+"在  ``SECURITY_RESET_URL`` 参数中指定. 默认为 ``False``."
 
 #: ../../configuration.rst:167
 msgid "``SECURITY_TRACKABLE``"
-msgstr ""
+msgstr "``SECURITY_TRACKABLE``"
 
 #: ../../configuration.rst:167
 msgid ""
-"Specifies if Flask-Security should track basic user login statistics. If "
-"set to ``True``, ensure your models have the required fields/attributes. "
-"Be sure to use `ProxyFix <http://flask.pocoo.org/docs/0.10/deploying"
-"/wsgi-standalone/#proxy-setups>` if you are using a proxy. Defaults to "
-"``False``"
+"Specifies if Flask-Security should track basic user login statistics. If set "
+"to ``True``, ensure your models have the required fields/attributes. Be sure "
+"to use `ProxyFix <http://flask.pocoo.org/docs/0.10/deploying/wsgi-standalone/"
+"#proxy-setups>`_ if you are using a proxy. Defaults to ``False``"
 msgstr ""
+"指定 Flask-Security 是否统计用户基本登录.  如果设置为 ``True``, 确认你的模型已"
+"经有需求的字段/熟悉. 请确认使用了 `ProxyFix <http://flask.pocoo.org/docs/0.10/"
+"deploying/wsgi-standalone/#proxy-setups>`_, 如果你使用一个代理. 默认为 "
+"``False``."
 
 #: ../../configuration.rst:172
 msgid "``SECURITY_PASSWORDLESS``"
-msgstr ""
+msgstr "``SECURITY_PASSWORDLESS``"
 
 #: ../../configuration.rst:172
 msgid ""
-"Specifies if Flask-Security should enable the passwordless login feature."
-" If set to ``True``, users are not required to enter a password to login "
-"but are sent an email with a login link. This feature is experimental and"
-" should be used with caution. Defaults to ``False``."
+"Specifies if Flask-Security should enable the passwordless login feature. If "
+"set to ``True``, users are not required to enter a password to login but are "
+"sent an email with a login link. This feature is experimental and should be "
+"used with caution. Defaults to ``False``."
 msgstr ""
+"指定 Flask-Security 是否开启无密码登录特性. 如果设置为 ``True``, 用户不被要求输"
+"入一个密码去登录, 而是发送一个含有登录链接的邮件. 这个特性时实验性的, 请小心使"
+"用. 默认设置为 ``False``."
 
 #: ../../configuration.rst:178
 msgid "``SECURITY_CHANGEABLE``"
-msgstr ""
+msgstr "``SECURITY_CHANGEABLE``"
 
 #: ../../configuration.rst:178
 msgid ""
-"Specifies if Flask-Security should enable the change password endpoint. "
-"The URL for this endpoint is specified by the ``SECURITY_CHANGE_URL`` "
+"Specifies if Flask-Security should enable the change password endpoint. The "
+"URL for this endpoint is specified by the ``SECURITY_CHANGE_URL`` "
 "configuration option. Defaults to ``False``."
 msgstr ""
+"指定 Flask-Security 是否启用用户修改密码端点 ( endpoint ). 这个端点的 URL 在  "
+"``SECURITY_CHANGE_URL`` 参数中指定. 默认为 ``False``."
 
 #: ../../configuration.rst:185
 msgid "Email"
-msgstr ""
+msgstr "邮件"
 
 #: ../../configuration.rst:190
 msgid "``SECURITY_EMAIL_SUBJECT_REGISTER``"
-msgstr ""
+msgstr "``SECURITY_EMAIL_SUBJECT_REGISTER``"
 
 #: ../../configuration.rst:190
 msgid "Sets the subject for the confirmation email. Defaults to ``Welcome``"
-msgstr ""
+msgstr "设置验证邮件主题. 默认为 ``Welcome``."
 
 #: ../../configuration.rst:193
 msgid "``SECURITY_EMAIL_SUBJECT_PASSWORDLESS``"
-msgstr ""
+msgstr "``SECURITY_EMAIL_SUBJECT_PASSWORDLESS``"
 
 #: ../../configuration.rst:193
 msgid ""
 "Sets the subject for the passwordless feature. Defaults to ``Login "
 "instructions``"
-msgstr ""
+msgstr "设置无密码登录特性主题. 默认为 ``Login instructions``."
 
 #: ../../configuration.rst:196
 msgid "``SECURITY_EMAIL_SUBJECT_PASSWORD_NOTICE``"
-msgstr ""
+msgstr "``SECURITY_EMAIL_SUBJECT_PASSWORD_NOTICE``"
 
 #: ../../configuration.rst:196
 msgid ""
-"Sets subject for the password notice. Defaults to ``Your password has "
-"been reset``"
-msgstr ""
+"Sets subject for the password notice. Defaults to ``Your password has been "
+"reset``"
+msgstr "设置密码提醒主题. 默认为 ``Your password has been reset``."
 
 #: ../../configuration.rst:199
 msgid "``SECURITY_EMAIL_SUBJECT_PASSWORD_RESET``"
-msgstr ""
+msgstr "``SECURITY_EMAIL_SUBJECT_PASSWORD_RESET``"
 
 #: ../../configuration.rst:199
 msgid ""
-"Sets the subject for the password reset email. Defaults to ``Password "
-"reset instructions``"
-msgstr ""
+"Sets the subject for the password reset email. Defaults to ``Password reset "
+"instructions``"
+msgstr "设置密码重置邮件主题. 默认为 ``Password reset instructions``."
 
 #: ../../configuration.rst:203
 msgid "``SECURITY_EMAIL_SUBJECT_PASSWORD_CHANGE_NOTICE``"
-msgstr ""
+msgstr "``SECURITY_EMAIL_SUBJECT_PASSWORD_CHANGE_NOTICE``"
 
 #: ../../configuration.rst:203
 msgid ""
-"Sets the subject for the password change notice. Defaults to ``Your "
-"password has been changed``"
-msgstr ""
+"Sets the subject for the password change notice. Defaults to ``Your password "
+"has been changed``"
+msgstr "设置密码改变提醒主题. 默认为  ``Your password has been changed``."
 
 #: ../../configuration.rst:207
 msgid "``SECURITY_EMAIL_SUBJECT_CONFIRM``"
-msgstr ""
+msgstr "``SECURITY_EMAIL_SUBJECT_CONFIRM``"
 
 #: ../../configuration.rst:207
 msgid ""
-"Sets the subject for the email confirmation message. Defaults to ``Please"
-" confirm your email``"
-msgstr ""
+"Sets the subject for the email confirmation message. Defaults to ``Please "
+"confirm your email``"
+msgstr "设置邮件验证信息主题. 默认为 ``Please confirm your email``."
 
 #: ../../configuration.rst:211
 msgid "``SECURITY_EMAIL_PLAINTEXT``"
-msgstr ""
+msgstr "``SECURITY_EMAIL_PLAINTEXT``"
 
 #: ../../configuration.rst:211
 msgid ""
-"Enable email to be sent as plaintext (Using *.txt template). Defaults "
-"``True``"
-msgstr ""
+"Enable email to be sent as plaintext (Using *.txt template). Defaults ``True``"
+msgstr "启用邮件以明文形式发送 ( 使用 *.txt 模板 ). 默认为 ``True``."
 
 #: ../../configuration.rst:214
 msgid "``SECURITY_EMAIL_HTML``"
-msgstr ""
+msgstr "``SECURITY_EMAIL_HTML``"
 
 #: ../../configuration.rst:214
 msgid ""
-"Enable email to be sent as plaintext (Using *.html template). Defaults "
-"``True``"
-msgstr ""
+"Enable email to be sent as plaintext (Using *.html template). Defaults ``True``"
+msgstr "启用邮件以明文形式发送 ( 使用 *.html 模板 ). 默认为 ``True``."
 
 #: ../../configuration.rst:220
 msgid "Miscellaneous"
-msgstr ""
+msgstr "杂项"
 
 #: ../../configuration.rst:225
 msgid "``SECURITY_USER_IDENTITY_ATTRIBUTES``"
-msgstr ""
+msgstr "``SECURITY_USER_IDENTITY_ATTRIBUTES``"
 
 #: ../../configuration.rst:225
 msgid ""
-"Specifies which attributes of the user object can be used for login. "
-"Defaults to ``['email']``."
-msgstr ""
+"Specifies which attributes of the user object can be used for login. Defaults "
+"to ``['email']``."
+msgstr "指定用户对象中,哪一个属性可以被用于登录. 默认为 ``['email']``."
 
 #: ../../configuration.rst:228
 msgid "``SECURITY_SEND_REGISTER_EMAIL``"
-msgstr ""
+msgstr "``SECURITY_SEND_REGISTER_EMAIL``"
 
 #: ../../configuration.rst:228
 msgid "Specifies whether registration email is sent. Defaults to ``True``."
-msgstr ""
+msgstr "指定注册邮件是否发送. 默认为 ``True``."
 
 #: ../../configuration.rst:231
 msgid "``SECURITY_SEND_PASSWORD_CHANGE_EMAIL``"
-msgstr ""
+msgstr "``SECURITY_SEND_PASSWORD_CHANGE_EMAIL``"
 
 #: ../../configuration.rst:231
 msgid "Specifies whether password change email is sent. Defaults to ``True``."
-msgstr ""
+msgstr "指定密码改变邮件是否发送. 默认为 ``True``."
 
 #: ../../configuration.rst:234
 msgid "``SECURITY_SEND_PASSWORD_RESET_NOTICE_EMAIL``"
-msgstr ""
+msgstr "``SECURITY_SEND_PASSWORD_RESET_NOTICE_EMAIL``"
 
 #: ../../configuration.rst:234
 msgid ""
-"Specifies whether password reset notice email is sent. Defaults to "
-"``True``."
-msgstr ""
+"Specifies whether password reset notice email is sent. Defaults to ``True``."
+msgstr "指定密码重置提醒邮件是否发送. 默认为 ``True``."
 
 #: ../../configuration.rst:238
 msgid "``SECURITY_CONFIRM_EMAIL_WITHIN``"
-msgstr ""
+msgstr "``SECURITY_CONFIRM_EMAIL_WITHIN``"
 
 #: ../../configuration.rst:238
 msgid ""
 "Specifies the amount of time a user has before their confirmation link "
 "expires. Always pluralized the time unit for this value. Defaults to ``5 "
 "days``."
-msgstr ""
+msgstr "指定验证链接过期时间. 这个值的时间单位总是复数. 默认为 ``5 days``."
 
 #: ../../configuration.rst:243
 msgid "``SECURITY_RESET_PASSWORD_WITHIN``"
-msgstr ""
+msgstr "``SECURITY_RESET_PASSWORD_WITHIN``"
 
 #: ../../configuration.rst:243
 msgid ""
 "Specifies the amount of time a user has before their password reset link "
 "expires. Always pluralized the time unit for this value. Defaults to ``5 "
 "days``."
-msgstr ""
+msgstr "指定重置密码链接过期时间. 这个值的时间单位总是复数. 默认为 ``5 days``."
 
 #: ../../configuration.rst:248
 msgid "``SECURITY_LOGIN_WITHIN``"
-msgstr ""
+msgstr "``SECURITY_LOGIN_WITHIN``"
 
 #: ../../configuration.rst:248
 msgid ""
-"Specifies the amount of time a user has before a login link expires. This"
-" is only used when the passwordless login feature is enabled. Always "
-"pluralized the time unit for this value. Defaults to ``1 days``."
+"Specifies the amount of time a user has before a login link expires. This is "
+"only used when the passwordless login feature is enabled. Always pluralized "
+"the time unit for this value. Defaults to ``1 days``."
 msgstr ""
+"指定登录链接过期时间. 这个只在无密码登录特性开启时使用. 这个值的时间单位总是复"
+"数. 默认为 ``1 days``."
 
 #: ../../configuration.rst:255
 msgid "``SECURITY_LOGIN_WITHOUT_CONFIRMATION``"
-msgstr ""
+msgstr "``SECURITY_LOGIN_WITHOUT_CONFIRMATION``"
 
 #: ../../configuration.rst:255
 msgid ""
-"Specifies if a user may login before confirming their email when the "
-"value of ``SECURITY_CONFIRMABLE`` is set to ``True``. Defaults to "
-"``False``."
+"Specifies if a user may login before confirming their email when the value of "
+"``SECURITY_CONFIRMABLE`` is set to ``True``. Defaults to ``False``."
 msgstr ""
+"指定当 ``SECURITY_CONFIRMABLE`` 为 ``True`` 时, 用户在验证其邮箱前是否能登录. "
+"默认为 ``False``."
 
 #: ../../configuration.rst:260
 msgid "``SECURITY_CONFIRM_SALT``"
-msgstr ""
+msgstr "``SECURITY_CONFIRM_SALT``"
 
 #: ../../configuration.rst:260
 msgid ""
-"Specifies the salt value when generating confirmation links/tokens. "
-"Defaults to ``confirm-salt``."
-msgstr ""
+"Specifies the salt value when generating confirmation links/tokens. Defaults "
+"to ``confirm-salt``."
+msgstr "指定生成验证链接/令牌的盐值. 默认为 ``confirm-salt``."
 
 #: ../../configuration.rst:264
 msgid "``SECURITY_RESET_SALT``"
-msgstr ""
+msgstr "``SECURITY_RESET_SALT``"
 
 #: ../../configuration.rst:264
 msgid ""
-"Specifies the salt value when generating password reset links/tokens. "
-"Defaults to ``reset-salt``."
-msgstr ""
+"Specifies the salt value when generating password reset links/tokens. Defaults "
+"to ``reset-salt``."
+msgstr "指定生成密码重置链接/令牌的盐值. 默认为 ``reset-salt``."
 
 #: ../../configuration.rst:268
 msgid "``SECURITY_LOGIN_SALT``"
-msgstr ""
+msgstr "``SECURITY_LOGIN_SALT``"
 
 #: ../../configuration.rst:268
 msgid ""
 "Specifies the salt value when generating login links/tokens. Defaults to "
 "``login-salt``."
-msgstr ""
+msgstr "指定生成登录链接/令牌的盐值. 默认为 ``login-salt``."
 
 #: ../../configuration.rst:271
 msgid "``SECURITY_REMEMBER_SALT``"
-msgstr ""
+msgstr "``SECURITY_REMEMBER_SALT``"
 
 #: ../../configuration.rst:271
 msgid ""
-"Specifies the salt value when generating remember tokens. Remember tokens"
-" are used instead of user ID's as it is more secure. Defaults to "
-"``remember-salt``."
+"Specifies the salt value when generating remember tokens. Remember tokens are "
+"used instead of user ID's as it is more secure. Defaults to ``remember-salt``."
 msgstr ""
+"指定生成\"记住我\"令牌的盐值. \"记住我\"令牌被用于代替用户 ID 因为他更安全. 默"
+"认为 ``remember-salt``."
 
 #: ../../configuration.rst:277
 msgid "``SECURITY_DEFAULT_REMEMBER_ME``"
-msgstr ""
+msgstr "``SECURITY_DEFAULT_REMEMBER_ME``"
 
 #: ../../configuration.rst:277
 msgid ""
 "Specifies the default \"remember me\" value used when logging in a user. "
 "Defaults to ``False``."
-msgstr ""
+msgstr "指定默认的 \"记住我\" 当用户登录时使用的值. 默认为 ``False``."
 
 #: ../../configuration.rst:283
 msgid "Messages"
-msgstr ""
+msgstr "消息文本"
 
 #: ../../configuration.rst:285
 msgid ""
-"The following are the messages Flask-Security uses.  They are tuples; the"
-" first element is the message and the second element is the error level."
+"The following are the messages Flask-Security uses.  They are tuples; the "
+"first element is the message and the second element is the error level."
 msgstr ""
+"下列是 Flask-Security  所用的消息文本. 他们是一个元组. 第一个元素是 消息 ,第二"
+"个元素是 错误等级."
 
 #: ../../configuration.rst:288
 msgid "The default messages and error levels can be found in ``core.py``."
-msgstr ""
+msgstr "默认的消息文本和错误等级可在 ``core.py`` 中找到."
 
 #: ../../configuration.rst:290
 msgid "``SECURITY_MSG_ALREADY_CONFIRMED``"
-msgstr ""
+msgstr "``SECURITY_MSG_ALREADY_CONFIRMED``"
 
 #: ../../configuration.rst:291
 msgid "``SECURITY_MSG_CONFIRMATION_EXPIRED``"
-msgstr ""
+msgstr "``SECURITY_MSG_CONFIRMATION_EXPIRED``"
 
 #: ../../configuration.rst:292
 msgid "``SECURITY_MSG_CONFIRMATION_REQUEST``"
-msgstr ""
+msgstr "``SECURITY_MSG_CONFIRMATION_REQUEST``"
 
 #: ../../configuration.rst:293
 msgid "``SECURITY_MSG_CONFIRMATION_REQUIRED``"
-msgstr ""
+msgstr "``SECURITY_MSG_CONFIRMATION_REQUIRED``"
 
 #: ../../configuration.rst:294
 msgid "``SECURITY_MSG_CONFIRM_REGISTRATION``"
-msgstr ""
+msgstr "``SECURITY_MSG_CONFIRM_REGISTRATION``"
 
 #: ../../configuration.rst:295
 msgid "``SECURITY_MSG_DISABLED_ACCOUNT``"
-msgstr ""
+msgstr "``SECURITY_MSG_DISABLED_ACCOUNT``"
 
 #: ../../configuration.rst:296
 msgid "``SECURITY_MSG_EMAIL_ALREADY_ASSOCIATED``"
-msgstr ""
+msgstr "``SECURITY_MSG_EMAIL_ALREADY_ASSOCIATED``"
 
 #: ../../configuration.rst:297
 msgid "``SECURITY_MSG_EMAIL_CONFIRMED``"
-msgstr ""
+msgstr "``SECURITY_MSG_EMAIL_CONFIRMED``"
 
 #: ../../configuration.rst:298
 msgid "``SECURITY_MSG_EMAIL_NOT_PROVIDED``"
-msgstr ""
+msgstr "``SECURITY_MSG_EMAIL_NOT_PROVIDED``"
 
 #: ../../configuration.rst:299
 msgid "``SECURITY_MSG_INVALID_CONFIRMATION_TOKEN``"
-msgstr ""
+msgstr "``SECURITY_MSG_INVALID_CONFIRMATION_TOKEN``"
 
 #: ../../configuration.rst:300
 msgid "``SECURITY_MSG_INVALID_EMAIL_ADDRESS``"
-msgstr ""
+msgstr "``SECURITY_MSG_INVALID_EMAIL_ADDRESS``"
 
 #: ../../configuration.rst:301
 msgid "``SECURITY_MSG_INVALID_LOGIN_TOKEN``"
-msgstr ""
+msgstr "``SECURITY_MSG_INVALID_LOGIN_TOKEN``"
 
 #: ../../configuration.rst:302
 msgid "``SECURITY_MSG_INVALID_PASSWORD``"
-msgstr ""
+msgstr "``SECURITY_MSG_INVALID_PASSWORD``"
 
 #: ../../configuration.rst:303
 msgid "``SECURITY_MSG_INVALID_REDIRECT``"
-msgstr ""
+msgstr "``SECURITY_MSG_INVALID_REDIRECT``"
 
 #: ../../configuration.rst:304
 msgid "``SECURITY_MSG_INVALID_RESET_PASSWORD_TOKEN``"
-msgstr ""
+msgstr "``SECURITY_MSG_INVALID_RESET_PASSWORD_TOKEN``"
 
 #: ../../configuration.rst:305
 msgid "``SECURITY_MSG_LOGIN``"
-msgstr ""
+msgstr "``SECURITY_MSG_LOGIN``"
 
 #: ../../configuration.rst:306
 msgid "``SECURITY_MSG_LOGIN_EMAIL_SENT``"
-msgstr ""
+msgstr "``SECURITY_MSG_LOGIN_EMAIL_SENT``"
 
 #: ../../configuration.rst:307
 msgid "``SECURITY_MSG_LOGIN_EXPIRED``"
-msgstr ""
+msgstr "``SECURITY_MSG_LOGIN_EXPIRED``"
 
 #: ../../configuration.rst:308
 msgid "``SECURITY_MSG_PASSWORDLESS_LOGIN_SUCCESSFUL``"
-msgstr ""
+msgstr "``SECURITY_MSG_PASSWORDLESS_LOGIN_SUCCESSFUL``"
 
 #: ../../configuration.rst:309
 msgid "``SECURITY_MSG_PASSWORD_CHANGE``"
-msgstr ""
+msgstr "``SECURITY_MSG_PASSWORD_CHANGE``"
 
 #: ../../configuration.rst:310
 msgid "``SECURITY_MSG_PASSWORD_INVALID_LENGTH``"
-msgstr ""
+msgstr "``SECURITY_MSG_PASSWORD_INVALID_LENGTH``"
 
 #: ../../configuration.rst:311
 msgid "``SECURITY_MSG_PASSWORD_IS_THE_SAME``"
-msgstr ""
+msgstr "``SECURITY_MSG_PASSWORD_IS_THE_SAME``"
 
 #: ../../configuration.rst:312
 msgid "``SECURITY_MSG_PASSWORD_MISMATCH``"
-msgstr ""
+msgstr "``SECURITY_MSG_PASSWORD_MISMATCH``"
 
 #: ../../configuration.rst:313
 msgid "``SECURITY_MSG_PASSWORD_NOT_PROVIDED``"
-msgstr ""
+msgstr "``SECURITY_MSG_PASSWORD_NOT_PROVIDED``"
 
 #: ../../configuration.rst:314
 msgid "``SECURITY_MSG_PASSWORD_NOT_SET``"
-msgstr ""
+msgstr "``SECURITY_MSG_PASSWORD_NOT_SET``"
 
 #: ../../configuration.rst:315
 msgid "``SECURITY_MSG_PASSWORD_RESET``"
-msgstr ""
+msgstr "``SECURITY_MSG_PASSWORD_RESET``"
 
 #: ../../configuration.rst:316
 msgid "``SECURITY_MSG_PASSWORD_RESET_EXPIRED``"
-msgstr ""
+msgstr "``SECURITY_MSG_PASSWORD_RESET_EXPIRED``"
 
 #: ../../configuration.rst:317
 msgid "``SECURITY_MSG_PASSWORD_RESET_REQUEST``"
-msgstr ""
+msgstr "``SECURITY_MSG_PASSWORD_RESET_REQUEST``"
 
 #: ../../configuration.rst:318
 msgid "``SECURITY_MSG_REFRESH``"
-msgstr ""
+msgstr "``SECURITY_MSG_REFRESH``"
 
 #: ../../configuration.rst:319
 msgid "``SECURITY_MSG_RETYPE_PASSWORD_MISMATCH``"
-msgstr ""
+msgstr "``SECURITY_MSG_RETYPE_PASSWORD_MISMATCH``"
 
 #: ../../configuration.rst:320
 msgid "``SECURITY_MSG_UNAUTHORIZED``"
-msgstr ""
+msgstr "``SECURITY_MSG_UNAUTHORIZED``"
 
 #: ../../configuration.rst:321
 msgid "``SECURITY_MSG_USER_DOES_NOT_EXIST``"
-msgstr ""
-
+msgstr "``SECURITY_MSG_USER_DOES_NOT_EXIST``"

--- a/docs/locale/zh-CN/LC_MESSAGES/customizing.po
+++ b/docs/locale/zh-CN/LC_MESSAGES/customizing.po
@@ -1,0 +1,285 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2012, Matt Wright
+# This file is distributed under the same license as the Flask-Security
+# package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Flask-Security 1.7.5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-03-28 10:58+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.4.0\n"
+
+#: ../../customizing.rst:2
+msgid "Customizing Views"
+msgstr ""
+
+#: ../../customizing.rst:4
+msgid ""
+"Flask-Security bootstraps your application with various views for "
+"handling its configured features to get you up and running as quickly as "
+"possible. However, you'll probably want to change the way these views "
+"look to be more in line with your application's visual design."
+msgstr ""
+
+#: ../../customizing.rst:11
+msgid "Views"
+msgstr ""
+
+#: ../../customizing.rst:13
+msgid ""
+"Flask-Security is packaged with a default template for each view it "
+"presents to a user. Templates are located within a subfolder named "
+"``security``. The following is a list of view templates:"
+msgstr ""
+
+#: ../../customizing.rst:17
+msgid "`security/forgot_password.html`"
+msgstr ""
+
+#: ../../customizing.rst:18
+msgid "`security/login_user.html`"
+msgstr ""
+
+#: ../../customizing.rst:19
+msgid "`security/register_user.html`"
+msgstr ""
+
+#: ../../customizing.rst:20
+msgid "`security/reset_password.html`"
+msgstr ""
+
+#: ../../customizing.rst:21
+msgid "`security/change_password.html`"
+msgstr ""
+
+#: ../../customizing.rst:22
+msgid "`security/send_confirmation.html`"
+msgstr ""
+
+#: ../../customizing.rst:23
+msgid "`security/send_login.html`"
+msgstr ""
+
+#: ../../customizing.rst:25 ../../customizing.rst:126
+msgid "Overriding these templates is simple:"
+msgstr ""
+
+#: ../../customizing.rst:27 ../../customizing.rst:128
+msgid ""
+"Create a folder named ``security`` within your application's templates "
+"folder"
+msgstr ""
+
+#: ../../customizing.rst:28 ../../customizing.rst:130
+msgid "Create a template with the same name for the template you wish to override"
+msgstr ""
+
+#: ../../customizing.rst:30
+msgid ""
+"You can also specify custom template file paths in the "
+":doc:`configuration <configuration>`."
+msgstr ""
+
+#: ../../customizing.rst:32
+msgid ""
+"Each template is passed a template context object that includes the "
+"following, including the objects/values that are passed to the template "
+"by the main Flask application context processor:"
+msgstr ""
+
+#: ../../customizing.rst:36
+msgid "``<template_name>_form``: A form object for the view"
+msgstr ""
+
+#: ../../customizing.rst:37
+msgid "``security``: The Flask-Security extension object"
+msgstr ""
+
+#: ../../customizing.rst:39
+msgid ""
+"To add more values to the template context, you can specify a context "
+"processor for all views or a specific view. For example::"
+msgstr ""
+
+#: ../../customizing.rst:54
+msgid "The following is a list of all the available context processor decorators:"
+msgstr ""
+
+#: ../../customizing.rst:56
+msgid "``context_processor``: All views"
+msgstr ""
+
+#: ../../customizing.rst:57
+msgid "``forgot_password_context_processor``: Forgot password view"
+msgstr ""
+
+#: ../../customizing.rst:58
+msgid "``login_context_processor``: Login view"
+msgstr ""
+
+#: ../../customizing.rst:59
+msgid "``register_context_processor``: Register view"
+msgstr ""
+
+#: ../../customizing.rst:60
+msgid "``reset_password_context_processor``: Reset password view"
+msgstr ""
+
+#: ../../customizing.rst:61
+msgid "``change_password_context_processor``: Reset password view"
+msgstr ""
+
+#: ../../customizing.rst:62
+msgid "``send_confirmation_context_processor``: Send confirmation view"
+msgstr ""
+
+#: ../../customizing.rst:63
+msgid "``send_login_context_processor``: Send login view"
+msgstr ""
+
+#: ../../customizing.rst:67
+msgid "Forms"
+msgstr ""
+
+#: ../../customizing.rst:69
+msgid ""
+"All forms can be overridden. For each form used, you can specify a "
+"replacement class. This allows you to add extra fields to the register "
+"form or override validators::"
+msgstr ""
+
+#: ../../customizing.rst:82
+msgid ""
+"For the ``register_form`` and ``confirm_register_form``, each field is "
+"passed to the user model (as kwargs) when a user is created. In the above"
+" case, the ``first_name`` and ``last_name`` fields are passed directly to"
+" the model, so the model should look like::"
+msgstr ""
+
+#: ../../customizing.rst:94
+msgid "The following is a list of all the available form overrides:"
+msgstr ""
+
+#: ../../customizing.rst:96
+msgid "``login_form``: Login form"
+msgstr ""
+
+#: ../../customizing.rst:97
+msgid "``confirm_register_form``: Confirmable register form"
+msgstr ""
+
+#: ../../customizing.rst:98
+msgid "``register_form``: Register form"
+msgstr ""
+
+#: ../../customizing.rst:99
+msgid "``forgot_password_form``: Forgot password form"
+msgstr ""
+
+#: ../../customizing.rst:100
+msgid "``reset_password_form``: Reset password form"
+msgstr ""
+
+#: ../../customizing.rst:101
+msgid "``change_password_form``: Reset password form"
+msgstr ""
+
+#: ../../customizing.rst:102
+msgid "``send_confirmation_form``: Send confirmation form"
+msgstr ""
+
+#: ../../customizing.rst:103
+msgid "``passwordless_login_form``: Passwordless login form"
+msgstr ""
+
+#: ../../customizing.rst:107
+msgid "Emails"
+msgstr ""
+
+#: ../../customizing.rst:109
+msgid ""
+"Flask-Security is also packaged with a default template for each email "
+"that it may send. Templates are located within the subfolder named "
+"``security/email``. The following is a list of email templates:"
+msgstr ""
+
+#: ../../customizing.rst:113
+msgid "`security/email/confirmation_instructions.html`"
+msgstr ""
+
+#: ../../customizing.rst:114
+msgid "`security/email/confirmation_instructions.txt`"
+msgstr ""
+
+#: ../../customizing.rst:115
+msgid "`security/email/login_instructions.html`"
+msgstr ""
+
+#: ../../customizing.rst:116
+msgid "`security/email/login_instructions.txt`"
+msgstr ""
+
+#: ../../customizing.rst:117
+msgid "`security/email/reset_instructions.html`"
+msgstr ""
+
+#: ../../customizing.rst:118
+msgid "`security/email/reset_instructions.txt`"
+msgstr ""
+
+#: ../../customizing.rst:119
+msgid "`security/email/reset_notice.html`"
+msgstr ""
+
+#: ../../customizing.rst:120
+msgid "`security/email/change_notice.txt`"
+msgstr ""
+
+#: ../../customizing.rst:121
+msgid "`security/email/change_notice.html`"
+msgstr ""
+
+#: ../../customizing.rst:122
+msgid "`security/email/reset_notice.txt`"
+msgstr ""
+
+#: ../../customizing.rst:123
+msgid "`security/email/welcome.html`"
+msgstr ""
+
+#: ../../customizing.rst:124
+msgid "`security/email/welcome.txt`"
+msgstr ""
+
+#: ../../customizing.rst:129
+msgid "Create a folder named ``email`` within the ``security`` folder"
+msgstr ""
+
+#: ../../customizing.rst:132
+msgid ""
+"Each template is passed a template context object that includes values "
+"for any links that are required in the email. If you require more values "
+"in the templates, you can specify an email context processor with the "
+"``mail_context_processor`` decorator. For example::"
+msgstr ""
+
+#: ../../customizing.rst:146
+msgid "Emails with Celery"
+msgstr ""
+
+#: ../../customizing.rst:148
+msgid ""
+"Sometimes it makes sense to send emails via a task queue, such as "
+"`Celery`_. To delay the sending of emails, you can use the "
+"``@security.send_mail_task`` decorator like so::"
+msgstr ""
+

--- a/docs/locale/zh-CN/LC_MESSAGES/customizing.po
+++ b/docs/locale/zh-CN/LC_MESSAGES/customizing.po
@@ -4,282 +4,303 @@
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 1.7.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-28 10:58+0800\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"POT-Creation-Date: 2017-03-28 11:58+0800\n"
+"PO-Revision-Date: 2017-03-28 15:16+0800\n"
+"Last-Translator: \n"
+"Language: zh_CN\n"
+"Language-Team: \n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.4.0\n"
+"X-Generator: Poedit 1.8.6\n"
 
 #: ../../customizing.rst:2
 msgid "Customizing Views"
-msgstr ""
+msgstr "自定义视图"
 
 #: ../../customizing.rst:4
 msgid ""
-"Flask-Security bootstraps your application with various views for "
-"handling its configured features to get you up and running as quickly as "
-"possible. However, you'll probably want to change the way these views "
-"look to be more in line with your application's visual design."
+"Flask-Security bootstraps your application with various views for handling its "
+"configured features to get you up and running as quickly as possible. However, "
+"you'll probably want to change the way these views look to be more in line with "
+"your application's visual design."
 msgstr ""
+"Flask-Security 为你的应用引入了多种多样的视图去处理已配置的特性, 让其能最快的启"
+"动并运行.\n"
+"但是, 你可能需要修改视图的样子, 使其更符合你应用的视觉设计."
 
 #: ../../customizing.rst:11
 msgid "Views"
-msgstr ""
+msgstr "视图"
 
 #: ../../customizing.rst:13
 msgid ""
-"Flask-Security is packaged with a default template for each view it "
-"presents to a user. Templates are located within a subfolder named "
-"``security``. The following is a list of view templates:"
+"Flask-Security is packaged with a default template for each view it presents to "
+"a user. Templates are located within a subfolder named ``security``. The "
+"following is a list of view templates:"
 msgstr ""
+"Flask-Security 为每个呈现给用户的视图打包了默认的模板. 这些模板位于叫做 "
+"``security`` 的子文件夹下. 下面是视图的模板列表:"
 
 #: ../../customizing.rst:17
 msgid "`security/forgot_password.html`"
-msgstr ""
+msgstr "`security/forgot_password.html`"
 
 #: ../../customizing.rst:18
 msgid "`security/login_user.html`"
-msgstr ""
+msgstr "`security/login_user.html`"
 
 #: ../../customizing.rst:19
 msgid "`security/register_user.html`"
-msgstr ""
+msgstr "`security/register_user.html`"
 
 #: ../../customizing.rst:20
 msgid "`security/reset_password.html`"
-msgstr ""
+msgstr "`security/reset_password.html`"
 
 #: ../../customizing.rst:21
 msgid "`security/change_password.html`"
-msgstr ""
+msgstr "`security/change_password.html`"
 
 #: ../../customizing.rst:22
 msgid "`security/send_confirmation.html`"
-msgstr ""
+msgstr "`security/send_confirmation.html`"
 
 #: ../../customizing.rst:23
 msgid "`security/send_login.html`"
-msgstr ""
+msgstr "`security/send_login.html`"
 
 #: ../../customizing.rst:25 ../../customizing.rst:126
 msgid "Overriding these templates is simple:"
-msgstr ""
+msgstr "重写这些模板很简单:"
 
 #: ../../customizing.rst:27 ../../customizing.rst:128
 msgid ""
-"Create a folder named ``security`` within your application's templates "
-"folder"
-msgstr ""
+"Create a folder named ``security`` within your application's templates folder"
+msgstr "在你应用的模板文件夹下, 创建一个叫做 ``security`` 的文件夹"
 
 #: ../../customizing.rst:28 ../../customizing.rst:130
 msgid "Create a template with the same name for the template you wish to override"
-msgstr ""
+msgstr "创建一个模板文件, 名字和你想重写的模板相同"
 
 #: ../../customizing.rst:30
 msgid ""
-"You can also specify custom template file paths in the "
-":doc:`configuration <configuration>`."
-msgstr ""
+"You can also specify custom template file paths in the :doc:`configuration "
+"<configuration>`."
+msgstr "你也可以在 :doc:`配置 <configuration>` 中自定义模板文件路径."
 
 #: ../../customizing.rst:32
 msgid ""
-"Each template is passed a template context object that includes the "
-"following, including the objects/values that are passed to the template "
-"by the main Flask application context processor:"
+"Each template is passed a template context object that includes the following, "
+"including the objects/values that are passed to the template by the main Flask "
+"application context processor:"
 msgstr ""
+"每个模板都被传递一个包含以下内容的模板上下文对象, 包括通过Flask主应用上下文处理"
+"器传递的 对象 或 值 :"
 
 #: ../../customizing.rst:36
 msgid "``<template_name>_form``: A form object for the view"
-msgstr ""
+msgstr "``<template_name>_form``: 视图的一个表单对象"
 
 #: ../../customizing.rst:37
 msgid "``security``: The Flask-Security extension object"
-msgstr ""
+msgstr "``security``: Flask-Security 的扩展对象"
 
 #: ../../customizing.rst:39
 msgid ""
-"To add more values to the template context, you can specify a context "
-"processor for all views or a specific view. For example::"
+"To add more values to the template context, you can specify a context processor "
+"for all views or a specific view. For example::"
 msgstr ""
+"为了增加更多的值给模板上下文, 你可以指定一个上下文处理器给所有视图或某个指定的视"
+"图, 例如:"
 
 #: ../../customizing.rst:54
 msgid "The following is a list of all the available context processor decorators:"
-msgstr ""
+msgstr "下列是所有可用的上下文处理器装饰器:"
 
 #: ../../customizing.rst:56
 msgid "``context_processor``: All views"
-msgstr ""
+msgstr "``context_processor``: 所有视图"
 
 #: ../../customizing.rst:57
 msgid "``forgot_password_context_processor``: Forgot password view"
-msgstr ""
+msgstr "``forgot_password_context_processor``: 忘记密码视图"
 
 #: ../../customizing.rst:58
 msgid "``login_context_processor``: Login view"
-msgstr ""
+msgstr "``login_context_processor``: 登录视图"
 
 #: ../../customizing.rst:59
 msgid "``register_context_processor``: Register view"
-msgstr ""
+msgstr "``register_context_processor``: 注册视图"
 
 #: ../../customizing.rst:60
 msgid "``reset_password_context_processor``: Reset password view"
-msgstr ""
+msgstr "``reset_password_context_processor``: 重置密码视图"
 
 #: ../../customizing.rst:61
-msgid "``change_password_context_processor``: Reset password view"
-msgstr ""
+msgid "``change_password_context_processor``: Change password view"
+msgstr "``change_password_context_processor``: 修改密码视图"
 
 #: ../../customizing.rst:62
 msgid "``send_confirmation_context_processor``: Send confirmation view"
-msgstr ""
+msgstr "``send_confirmation_context_processor``: 发送验证视图"
 
 #: ../../customizing.rst:63
 msgid "``send_login_context_processor``: Send login view"
-msgstr ""
+msgstr "``send_login_context_processor``: 发送登录视图"
 
 #: ../../customizing.rst:67
 msgid "Forms"
-msgstr ""
+msgstr "表单"
 
 #: ../../customizing.rst:69
 msgid ""
-"All forms can be overridden. For each form used, you can specify a "
-"replacement class. This allows you to add extra fields to the register "
-"form or override validators::"
+"All forms can be overridden. For each form used, you can specify a replacement "
+"class. This allows you to add extra fields to the register form or override "
+"validators::"
 msgstr ""
+"所有的表单可以被重写. 你可以给每个被使用的表单指定一个代替的类. 这将允许你给注册"
+"表单增加额外的字段或者重写验证器:"
 
 #: ../../customizing.rst:82
 msgid ""
-"For the ``register_form`` and ``confirm_register_form``, each field is "
-"passed to the user model (as kwargs) when a user is created. In the above"
-" case, the ``first_name`` and ``last_name`` fields are passed directly to"
-" the model, so the model should look like::"
+"For the ``register_form`` and ``confirm_register_form``, each field is passed "
+"to the user model (as kwargs) when a user is created. In the above case, the "
+"``first_name`` and ``last_name`` fields are passed directly to the model, so "
+"the model should look like::"
 msgstr ""
+"对于 ``register_form`` 和 ``confirm_register_form``, 当一个用户被创建时, 每个字"
+"段都会被传输到用户模型 ( 作为 kwargs ). 上面的例子中的 ``first_name`` 和 "
+"``last_name`` 被直接传递到模型, 所以模型看起来应该像这样:"
 
 #: ../../customizing.rst:94
 msgid "The following is a list of all the available form overrides:"
-msgstr ""
+msgstr "下面下列是所有可重写的表单:"
 
 #: ../../customizing.rst:96
 msgid "``login_form``: Login form"
-msgstr ""
+msgstr "``login_form``: 登录表单"
 
 #: ../../customizing.rst:97
 msgid "``confirm_register_form``: Confirmable register form"
-msgstr ""
+msgstr "``confirm_register_form``: 验证注册表单"
 
 #: ../../customizing.rst:98
 msgid "``register_form``: Register form"
-msgstr ""
+msgstr "``register_form``: 注册表单"
 
 #: ../../customizing.rst:99
 msgid "``forgot_password_form``: Forgot password form"
-msgstr ""
+msgstr "``forgot_password_form``: 忘记密码表单"
 
 #: ../../customizing.rst:100
 msgid "``reset_password_form``: Reset password form"
-msgstr ""
+msgstr "``reset_password_form``: 重置密码表单"
 
 #: ../../customizing.rst:101
-msgid "``change_password_form``: Reset password form"
-msgstr ""
+msgid "``change_password_form``: Change password form"
+msgstr "``change_password_form``: 修改密码表单"
 
 #: ../../customizing.rst:102
 msgid "``send_confirmation_form``: Send confirmation form"
-msgstr ""
+msgstr "``send_confirmation_form``: 发送验证表单"
 
 #: ../../customizing.rst:103
 msgid "``passwordless_login_form``: Passwordless login form"
-msgstr ""
+msgstr "``passwordless_login_form``: 无密码登录表单"
 
 #: ../../customizing.rst:107
 msgid "Emails"
-msgstr ""
+msgstr "邮件"
 
 #: ../../customizing.rst:109
 msgid ""
-"Flask-Security is also packaged with a default template for each email "
-"that it may send. Templates are located within the subfolder named "
-"``security/email``. The following is a list of email templates:"
+"Flask-Security is also packaged with a default template for each email that it "
+"may send. Templates are located within the subfolder named ``security/email``. "
+"The following is a list of email templates:"
 msgstr ""
+"Flask-Security 也同样打包了默认模板给可能被发送的邮件使用. 这些模板被放置在叫做 "
+"``security/email`` 的子文件夹中. 下面时邮件模板列表:"
 
 #: ../../customizing.rst:113
 msgid "`security/email/confirmation_instructions.html`"
-msgstr ""
+msgstr "`security/email/confirmation_instructions.html`"
 
 #: ../../customizing.rst:114
 msgid "`security/email/confirmation_instructions.txt`"
-msgstr ""
+msgstr "`security/email/confirmation_instructions.txt`"
 
 #: ../../customizing.rst:115
 msgid "`security/email/login_instructions.html`"
-msgstr ""
+msgstr "`security/email/login_instructions.html`"
 
 #: ../../customizing.rst:116
 msgid "`security/email/login_instructions.txt`"
-msgstr ""
+msgstr "`security/email/login_instructions.txt`"
 
 #: ../../customizing.rst:117
 msgid "`security/email/reset_instructions.html`"
-msgstr ""
+msgstr "`security/email/reset_instructions.html`"
 
 #: ../../customizing.rst:118
 msgid "`security/email/reset_instructions.txt`"
-msgstr ""
+msgstr "`security/email/reset_instructions.txt`"
 
 #: ../../customizing.rst:119
 msgid "`security/email/reset_notice.html`"
-msgstr ""
+msgstr "`security/email/reset_notice.html`"
 
 #: ../../customizing.rst:120
 msgid "`security/email/change_notice.txt`"
-msgstr ""
+msgstr "`security/email/change_notice.txt`"
 
 #: ../../customizing.rst:121
 msgid "`security/email/change_notice.html`"
-msgstr ""
+msgstr "`security/email/change_notice.html`"
 
 #: ../../customizing.rst:122
 msgid "`security/email/reset_notice.txt`"
-msgstr ""
+msgstr "`security/email/reset_notice.txt`"
 
 #: ../../customizing.rst:123
 msgid "`security/email/welcome.html`"
-msgstr ""
+msgstr "`security/email/welcome.html`"
 
 #: ../../customizing.rst:124
 msgid "`security/email/welcome.txt`"
-msgstr ""
+msgstr "`security/email/welcome.txt`"
 
 #: ../../customizing.rst:129
 msgid "Create a folder named ``email`` within the ``security`` folder"
-msgstr ""
+msgstr "创建一个叫做 ``email`` 的文件夹在 ``security`` 文件夹中"
 
 #: ../../customizing.rst:132
 msgid ""
-"Each template is passed a template context object that includes values "
-"for any links that are required in the email. If you require more values "
-"in the templates, you can specify an email context processor with the "
+"Each template is passed a template context object that includes values for any "
+"links that are required in the email. If you require more values in the "
+"templates, you can specify an email context processor with the "
 "``mail_context_processor`` decorator. For example::"
 msgstr ""
+"每个模板都被传递一个模板上下文对象, 这个模板上下文对象包含任何邮件需要的链接的"
+"值. 如果你想要在模板中有更多的值, 你可以使用 ``mail_context_processor`` 装饰器来"
+"指定一个邮箱上下文处理器. 举个例子:"
 
 #: ../../customizing.rst:146
 msgid "Emails with Celery"
-msgstr ""
+msgstr "使用 Celery 发送邮件"
 
 #: ../../customizing.rst:148
 msgid ""
-"Sometimes it makes sense to send emails via a task queue, such as "
-"`Celery`_. To delay the sending of emails, you can use the "
-"``@security.send_mail_task`` decorator like so::"
+"Sometimes it makes sense to send emails via a task queue, such as `Celery`_. To "
+"delay the sending of emails, you can use the ``@security.send_mail_task`` "
+"decorator like so::"
 msgstr ""
-
+"有时候使用任务队列发送邮件很有意义, 例如  `Celery`_.  为了延期邮件的发送, 你可以"
+"像这样使用 ``@security.send_mail_task`` 装饰器:"

--- a/docs/locale/zh-CN/LC_MESSAGES/features.po
+++ b/docs/locale/zh-CN/LC_MESSAGES/features.po
@@ -1,0 +1,212 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2012, Matt Wright
+# This file is distributed under the same license as the Flask-Security
+# package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Flask-Security 1.7.5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-03-28 10:58+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.4.0\n"
+
+#: ../../features.rst:2
+msgid "Features"
+msgstr ""
+
+#: ../../features.rst:4
+msgid ""
+"Flask-Security allows you to quickly add common security mechanisms to "
+"your Flask application. They include:"
+msgstr ""
+
+#: ../../features.rst:9
+msgid "Session Based Authentication"
+msgstr ""
+
+#: ../../features.rst:11
+msgid ""
+"Session based authentication is fulfilled entirely by the `Flask-Login`_ "
+"extension. Flask-Security handles the configuration of Flask-Login "
+"automatically based on a few of its own configuration values and uses "
+"Flask-Login's `alternative token`_ feature for remembering users when "
+"their session has expired."
+msgstr ""
+
+#: ../../features.rst:19
+msgid "Role/Identity Based Access"
+msgstr ""
+
+#: ../../features.rst:21
+msgid ""
+"Flask-Security implements very basic role management out of the box. This"
+" means that you can associate a high level role or multiple roles to any "
+"user. For instance, you may assign roles such as `Admin`, `Editor`, "
+"`SuperUser`, or a combination of said roles to a user. Access control is "
+"based on the role name and all roles should be uniquely named. This "
+"feature is implemented using the `Flask-Principal`_ extension. If you'd "
+"like to implement more granular access control, you can refer to the "
+"Flask-Principal `documentation on this topic`_."
+msgstr ""
+
+#: ../../features.rst:31
+msgid "Password Encryption"
+msgstr ""
+
+#: ../../features.rst:33
+msgid ""
+"Password encryption is enabled with `passlib`_. Passwords are stored in "
+"plain text by default but you can easily configure the encryption "
+"algorithm. You should **always use an encryption algorithm** in your "
+"production environment. You may also specify to use HMAC with a "
+"configured salt value in addition to the algorithm chosen. Bear in mind "
+"passlib does not assume which algorithm you will choose and may require "
+"additional libraries to be installed."
+msgstr ""
+
+#: ../../features.rst:42
+msgid "Basic HTTP Authentication"
+msgstr ""
+
+#: ../../features.rst:44
+msgid ""
+"Basic HTTP authentication is achievable using a simple view method "
+"decorator. This feature expects the incoming authentication information "
+"to identify a user in the system. This means that the username must be "
+"equal to their email address."
+msgstr ""
+
+#: ../../features.rst:50
+msgid "Token Authentication"
+msgstr ""
+
+#: ../../features.rst:52
+msgid ""
+"Token based authentication is enabled by retrieving the user auth token "
+"by performing an HTTP POST with the authentication details as JSON data "
+"against the authentication endpoint. A successful call to this endpoint "
+"will return the user's ID and their authentication token. This token can "
+"be used in subsequent requests to protected resources. The auth token is "
+"supplied in the request through an HTTP header or query string parameter."
+" By default the HTTP header name is `Authentication-Token` and the "
+"default query string parameter name is `auth_token`. Authentication "
+"tokens are generated using the user's password. Thus if the user changes "
+"his or her password their existing authentication token will become "
+"invalid. A new token will need to be retrieved using the user's new "
+"password."
+msgstr ""
+
+#: ../../features.rst:66
+msgid "Email Confirmation"
+msgstr ""
+
+#: ../../features.rst:68
+msgid ""
+"If desired you can require that new users confirm their email address. "
+"Flask-Security will send an email message to any new users with a "
+"confirmation link. Upon navigating to the confirmation link, the user "
+"will be automatically logged in. There is also view for resending a "
+"confirmation link to a given email if the user happens to try to use an "
+"expired token or has lost the previous email. Confirmation links can be "
+"configured to expire after a specified amount of time."
+msgstr ""
+
+#: ../../features.rst:78
+msgid "Password Reset/Recovery"
+msgstr ""
+
+#: ../../features.rst:80
+msgid ""
+"Password reset and recovery is available for when a user forgets his or "
+"her password. Flask-Security sends an email to the user with a link to a "
+"view which they can reset their password. Once the password is reset they"
+" are automatically logged in and can use the new password from then on. "
+"Password reset links  can be configured to expire after a specified "
+"amount of time."
+msgstr ""
+
+#: ../../features.rst:88
+msgid "User Registration"
+msgstr ""
+
+#: ../../features.rst:90
+msgid ""
+"Flask-Security comes packaged with a basic user registration view. This "
+"view is very simple and new users need only supply an email address and "
+"their password. This view can be overridden if your registration process "
+"requires more fields."
+msgstr ""
+
+#: ../../features.rst:96
+msgid "Login Tracking"
+msgstr ""
+
+#: ../../features.rst:98
+msgid ""
+"Flask-Security can, if configured, keep track of basic login events and "
+"statistics. They include:"
+msgstr ""
+
+#: ../../features.rst:101
+msgid "Last login date"
+msgstr ""
+
+#: ../../features.rst:102
+msgid "Current login date"
+msgstr ""
+
+#: ../../features.rst:103
+msgid "Last login IP address"
+msgstr ""
+
+#: ../../features.rst:104
+msgid "Current login IP address"
+msgstr ""
+
+#: ../../features.rst:105
+msgid "Total login count"
+msgstr ""
+
+#: ../../features.rst:109
+msgid "JSON/Ajax Support"
+msgstr ""
+
+#: ../../features.rst:111
+msgid ""
+"Flask-Security supports JSON/Ajax requests where appropriate. Just "
+"remember that all endpoints require a CSRF token just like HTML views. "
+"More specifically JSON is supported for the following operations:"
+msgstr ""
+
+#: ../../features.rst:115
+msgid "Login requests"
+msgstr ""
+
+#: ../../features.rst:116
+msgid "Registration requests"
+msgstr ""
+
+#: ../../features.rst:117
+msgid "Change password requests"
+msgstr ""
+
+#: ../../features.rst:118
+msgid "Confirmation requests"
+msgstr ""
+
+#: ../../features.rst:119
+msgid "Forgot password requests"
+msgstr ""
+
+#: ../../features.rst:120
+msgid "Passwordless login requests"
+msgstr ""
+

--- a/docs/locale/zh-CN/LC_MESSAGES/features.po
+++ b/docs/locale/zh-CN/LC_MESSAGES/features.po
@@ -4,33 +4,36 @@
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 1.7.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-28 10:58+0800\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"POT-Creation-Date: 2017-03-27 11:45+0800\n"
+"PO-Revision-Date: 2017-03-27 15:26+0800\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.4.0\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: zh_CN\n"
+"X-Generator: Poedit 1.8.6\n"
 
 #: ../../features.rst:2
 msgid "Features"
-msgstr ""
+msgstr "特性"
 
 #: ../../features.rst:4
 msgid ""
 "Flask-Security allows you to quickly add common security mechanisms to "
 "your Flask application. They include:"
 msgstr ""
+"Flask-Security 让你能够快捷的为你的 Flask 应用添加一些通用安全机制. 它们"
+"包括:"
 
 #: ../../features.rst:9
 msgid "Session Based Authentication"
-msgstr ""
+msgstr "基于会话的身份验证"
 
 #: ../../features.rst:11
 msgid ""
@@ -40,26 +43,37 @@ msgid ""
 "Flask-Login's `alternative token`_ feature for remembering users when "
 "their session has expired."
 msgstr ""
+"基于会话的身份验证由 `Flask-Login`_ 扩展完全实现. \n"
+"Flask-Security 会自动处理 Flask-Login 的配置,基于它的少数配置参数, \n"
+"同时使用Flask-Login 的 `可选令牌`_ 特性去记住用户,当它们的会话过期."
 
 #: ../../features.rst:19
 msgid "Role/Identity Based Access"
-msgstr ""
+msgstr "基于角色/身份的权限管理"
 
 #: ../../features.rst:21
 msgid ""
-"Flask-Security implements very basic role management out of the box. This"
-" means that you can associate a high level role or multiple roles to any "
-"user. For instance, you may assign roles such as `Admin`, `Editor`, "
+"Flask-Security implements very basic role management out of the box. "
+"This means that you can associate a high level role or multiple roles to "
+"any user. For instance, you may assign roles such as `Admin`, `Editor`, "
 "`SuperUser`, or a combination of said roles to a user. Access control is "
 "based on the role name and all roles should be uniquely named. This "
 "feature is implemented using the `Flask-Principal`_ extension. If you'd "
 "like to implement more granular access control, you can refer to the "
 "Flask-Principal `documentation on this topic`_."
 msgstr ""
+"Flask-Security 开箱即用的实现了非常基础的角色管理系统.\n"
+"这意味着你可以将一个高等级角色或多个角色关联于任何用户.\n"
+"例如, 你可以分配 `管理员`, `编辑`, `超级用户` 这些角色或者它们的组合给一"
+"个用户.\n"
+"权限控制基于角色名, 所有角色需要一个独一无二的名称. \n"
+"这个特性的实现通过使用 `Flask-Principal`_ 扩展. \n"
+"如果你想实现更细腻的权限控制,你可以参考 Flask-Principal `关于这一主题的文"
+"档`_."
 
 #: ../../features.rst:31
 msgid "Password Encryption"
-msgstr ""
+msgstr "密码加密"
 
 #: ../../features.rst:33
 msgid ""
@@ -71,10 +85,15 @@ msgid ""
 "passlib does not assume which algorithm you will choose and may require "
 "additional libraries to be installed."
 msgstr ""
+"密码加密通过 `passlib`_ 实现. 一般情况下, 密码储存为无格式文本, 不过你可"
+"以简便的配置加密算法. \n"
+"你应该在生产环境中 **永远使用一个加密算法**.\n"
+"除了加密算法,你也可以指定使用 HMAC 加上配置的盐. \n"
+"记住 passlib 不假定你将使用的算法,同时可能需要安装额外的库."
 
 #: ../../features.rst:42
 msgid "Basic HTTP Authentication"
-msgstr ""
+msgstr "基础 HTTP 身份验证"
 
 #: ../../features.rst:44
 msgid ""
@@ -83,10 +102,13 @@ msgid ""
 "to identify a user in the system. This means that the username must be "
 "equal to their email address."
 msgstr ""
+"基础 HTTP 身份验证 通过使用一个视图方法装饰器实现.\n"
+"这个特性期望通过给予的身份验证信息,去认定为系统中的一个用户.\n"
+"这意味着, 用户名必须和邮件地址一样."
 
 #: ../../features.rst:50
 msgid "Token Authentication"
-msgstr ""
+msgstr "基于令牌的身份验证"
 
 #: ../../features.rst:52
 msgid ""
@@ -95,18 +117,29 @@ msgid ""
 "against the authentication endpoint. A successful call to this endpoint "
 "will return the user's ID and their authentication token. This token can "
 "be used in subsequent requests to protected resources. The auth token is "
-"supplied in the request through an HTTP header or query string parameter."
-" By default the HTTP header name is `Authentication-Token` and the "
-"default query string parameter name is `auth_token`. Authentication "
+"supplied in the request through an HTTP header or query string "
+"parameter. By default the HTTP header name is `Authentication-Token` and "
+"the default query string parameter name is `auth_token`. Authentication "
 "tokens are generated using the user's password. Thus if the user changes "
 "his or her password their existing authentication token will become "
 "invalid. A new token will need to be retrieved using the user's new "
 "password."
 msgstr ""
+"基于令牌的身份验证是通过向 身份验证端点(endpoint),发送一个包含身份验证详"
+"细信息\n"
+"的 JSON 数据的 HTTP POST 请求,来获取用户认证令牌实现的.\n"
+"成功的调用这个端点,将返回用户的 ID 和身份验证令牌.\n"
+"这个令牌可用于之后对于受保护资源的请求. 令牌通过附于 HTTP 头或者字符串查"
+"询参数(query string parameter)中来提供.\n"
+"默认的 HTTP 头名称为 `Authentication-Token` ,字符串查询参数名称为 "
+"`auth_token`.\n"
+"身份验证令牌基于用户的密码产生. 因此,当一个用户修改了他的密码,他现存的身"
+"份验证令牌将失效.\n"
+"需要通过用户的新密码来获取一个新的令牌."
 
 #: ../../features.rst:66
 msgid "Email Confirmation"
-msgstr ""
+msgstr "邮箱验证"
 
 #: ../../features.rst:68
 msgid ""
@@ -118,24 +151,34 @@ msgid ""
 "expired token or has lost the previous email. Confirmation links can be "
 "configured to expire after a specified amount of time."
 msgstr ""
+"如果需要的话,你可以要求新用户去验证它们的邮箱地址.\n"
+"Flask-Security 将会给任何新用户发送一封包含验证链接的邮件.\n"
+"当用户跳转到验证链接时,用户会自动登录.\n"
+"也有一个视图可供重新发送验证链接到一个指定的邮箱,当一个用户试图使用过期的"
+"令牌或者丢失了之前的邮件.\n"
+"验证链接可以配置在指定时间后过期."
 
 #: ../../features.rst:78
 msgid "Password Reset/Recovery"
-msgstr ""
+msgstr "密码重置/恢复"
 
 #: ../../features.rst:80
 msgid ""
 "Password reset and recovery is available for when a user forgets his or "
 "her password. Flask-Security sends an email to the user with a link to a "
-"view which they can reset their password. Once the password is reset they"
-" are automatically logged in and can use the new password from then on. "
-"Password reset links  can be configured to expire after a specified "
+"view which they can reset their password. Once the password is reset "
+"they are automatically logged in and can use the new password from then "
+"on. Password reset links  can be configured to expire after a specified "
 "amount of time."
 msgstr ""
+"密码重置/恢复 为忘记密码的用户服务.\n"
+"Flask-Security 发送包含一个跳转到重置密码界面的链接.\n"
+"一旦密码被重置,用户将会自动登录,之后就可用他们的新密码了.\n"
+"密码重置链接可以配置在指定时间后过期."
 
 #: ../../features.rst:88
 msgid "User Registration"
-msgstr ""
+msgstr "用户注册"
 
 #: ../../features.rst:90
 msgid ""
@@ -144,40 +187,43 @@ msgid ""
 "their password. This view can be overridden if your registration process "
 "requires more fields."
 msgstr ""
+"Flask-Security 打包了一个基础的用户注册视图\n"
+"这个视图非常简单,新用户只需要提供一个邮箱地址和密码.\n"
+"这个视图可以被重写,如果你的注册过程需要填写更多的字段."
 
 #: ../../features.rst:96
 msgid "Login Tracking"
-msgstr ""
+msgstr "登录追踪"
 
 #: ../../features.rst:98
 msgid ""
 "Flask-Security can, if configured, keep track of basic login events and "
 "statistics. They include:"
-msgstr ""
+msgstr "通过配置, Flask-Security 可以持续追踪基础登录事件和统计. 它们包括:"
 
 #: ../../features.rst:101
 msgid "Last login date"
-msgstr ""
+msgstr "上一次登录时间"
 
 #: ../../features.rst:102
 msgid "Current login date"
-msgstr ""
+msgstr "当前登录时间"
 
 #: ../../features.rst:103
 msgid "Last login IP address"
-msgstr ""
+msgstr "上一次登录 IP 地址"
 
 #: ../../features.rst:104
 msgid "Current login IP address"
-msgstr ""
+msgstr "当前登录 IP 地址"
 
 #: ../../features.rst:105
 msgid "Total login count"
-msgstr ""
+msgstr "总登录次数"
 
 #: ../../features.rst:109
 msgid "JSON/Ajax Support"
-msgstr ""
+msgstr "JSON/Ajax 支持"
 
 #: ../../features.rst:111
 msgid ""
@@ -185,28 +231,30 @@ msgid ""
 "remember that all endpoints require a CSRF token just like HTML views. "
 "More specifically JSON is supported for the following operations:"
 msgstr ""
+"在适当情况下 Flask-Security 支持 JSON/Ajax 请求. \n"
+"记住,所有的端点和 HTML 视图一样需要 CSRF 令牌.\n"
+"具体来说,以下的操作支持 JSON:"
 
 #: ../../features.rst:115
 msgid "Login requests"
-msgstr ""
+msgstr "登录请求"
 
 #: ../../features.rst:116
 msgid "Registration requests"
-msgstr ""
+msgstr "注册请求"
 
 #: ../../features.rst:117
 msgid "Change password requests"
-msgstr ""
+msgstr "修改密码请求"
 
 #: ../../features.rst:118
 msgid "Confirmation requests"
-msgstr ""
+msgstr "验证请求"
 
 #: ../../features.rst:119
 msgid "Forgot password requests"
-msgstr ""
+msgstr "忘记密码请求"
 
 #: ../../features.rst:120
 msgid "Passwordless login requests"
-msgstr ""
-
+msgstr "无密码登录请求"

--- a/docs/locale/zh-CN/LC_MESSAGES/index.po
+++ b/docs/locale/zh-CN/LC_MESSAGES/index.po
@@ -1,0 +1,127 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2012, Matt Wright
+# This file is distributed under the same license as the Flask-Security
+# package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Flask-Security 1.7.5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-03-28 10:58+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.4.0\n"
+
+#: ../../index.rst:2
+msgid "Flask-Security"
+msgstr ""
+
+#: ../../index.rst:4
+msgid ""
+"Flask-Security allows you to quickly add common security mechanisms to "
+"your Flask application. They include:"
+msgstr ""
+
+#: ../../index.rst:7
+msgid "Session based authentication"
+msgstr ""
+
+#: ../../index.rst:8
+msgid "Role management"
+msgstr ""
+
+#: ../../index.rst:9
+msgid "Password encryption"
+msgstr ""
+
+#: ../../index.rst:10
+msgid "Basic HTTP authentication"
+msgstr ""
+
+#: ../../index.rst:11
+msgid "Token based authentication"
+msgstr ""
+
+#: ../../index.rst:12
+msgid "Token based account activation (optional)"
+msgstr ""
+
+#: ../../index.rst:13
+msgid "Token based password recovery / resetting (optional)"
+msgstr ""
+
+#: ../../index.rst:14
+msgid "User registration (optional)"
+msgstr ""
+
+#: ../../index.rst:15
+msgid "Login tracking (optional)"
+msgstr ""
+
+#: ../../index.rst:16
+msgid "JSON/Ajax Support"
+msgstr ""
+
+#: ../../index.rst:18
+msgid ""
+"Many of these features are made possible by integrating various Flask "
+"extensions and libraries. They include:"
+msgstr ""
+
+#: ../../index.rst:21
+msgid "`Flask-Login <http://packages.python.org/Flask-Login/>`_"
+msgstr ""
+
+#: ../../index.rst:22
+msgid "`Flask-Mail <http://packages.python.org/Flask-Mail/>`_"
+msgstr ""
+
+#: ../../index.rst:23
+msgid "`Flask-Principal <http://packages.python.org/Flask-Principal/>`_"
+msgstr ""
+
+#: ../../index.rst:24
+msgid "`Flask-Script <http://packages.python.org/Flask-Script/>`_"
+msgstr ""
+
+#: ../../index.rst:25
+msgid "`Flask-WTF <http://packages.python.org/Flask-WTF/>`_"
+msgstr ""
+
+#: ../../index.rst:26
+msgid "`itsdangerous <http://packages.python.org/itsdangerous/>`_"
+msgstr ""
+
+#: ../../index.rst:27
+msgid "`passlib <http://packages.python.org/passlib/>`_"
+msgstr ""
+
+#: ../../index.rst:29
+msgid ""
+"Additionally, it assumes you'll be using a common library for your "
+"database connections and model definitions. Flask-Security supports the "
+"following Flask extensions out of the box for data persistence:"
+msgstr ""
+
+#: ../../index.rst:33
+msgid "`Flask-SQLAlchemy <http://pypi.python.org/pypi/flask-sqlalchemy/>`_"
+msgstr ""
+
+#: ../../index.rst:34
+msgid "`Flask-MongoEngine <http://pypi.python.org/pypi/flask-mongoengine/>`_"
+msgstr ""
+
+#: ../../index.rst:35
+msgid "`Flask-Peewee <http://pypi.python.org/pypi/flask-peewee/>`_"
+msgstr ""
+
+#: ../../contents.rst.inc:2
+msgid "Contents"
+msgstr ""
+

--- a/docs/locale/zh-CN/LC_MESSAGES/index.po
+++ b/docs/locale/zh-CN/LC_MESSAGES/index.po
@@ -4,103 +4,106 @@
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 1.7.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-28 10:58+0800\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"POT-Creation-Date: 2017-03-27 11:45+0800\n"
+"PO-Revision-Date: 2017-03-27 15:16+0800\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.4.0\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: zh_CN\n"
+"X-Generator: Poedit 1.8.6\n"
 
 #: ../../index.rst:2
 msgid "Flask-Security"
-msgstr ""
+msgstr "Flask-Security"
 
 #: ../../index.rst:4
 msgid ""
 "Flask-Security allows you to quickly add common security mechanisms to "
 "your Flask application. They include:"
 msgstr ""
+"Flask-Security 让你能够快捷的为你的 Flask 应用添加一些通用安全机制. 它们包"
+"括:"
 
 #: ../../index.rst:7
 msgid "Session based authentication"
-msgstr ""
+msgstr "基于会话的身份验证"
 
 #: ../../index.rst:8
 msgid "Role management"
-msgstr ""
+msgstr "角色管理"
 
 #: ../../index.rst:9
 msgid "Password encryption"
-msgstr ""
+msgstr "密码加密"
 
 #: ../../index.rst:10
 msgid "Basic HTTP authentication"
-msgstr ""
+msgstr "基础 HTTP 身份验证"
 
 #: ../../index.rst:11
 msgid "Token based authentication"
-msgstr ""
+msgstr "基于令牌的身份验证"
 
 #: ../../index.rst:12
 msgid "Token based account activation (optional)"
-msgstr ""
+msgstr "基于令牌的账户激活 (可选)"
 
 #: ../../index.rst:13
 msgid "Token based password recovery / resetting (optional)"
-msgstr ""
+msgstr "基于令牌的密码恢复/重置 (可选)"
 
 #: ../../index.rst:14
 msgid "User registration (optional)"
-msgstr ""
+msgstr "用户注册 (可选)"
 
 #: ../../index.rst:15
 msgid "Login tracking (optional)"
-msgstr ""
+msgstr "登录追踪 (可选)"
 
 #: ../../index.rst:16
 msgid "JSON/Ajax Support"
-msgstr ""
+msgstr "JSON/Ajax 支持"
 
 #: ../../index.rst:18
 msgid ""
 "Many of these features are made possible by integrating various Flask "
 "extensions and libraries. They include:"
-msgstr ""
+msgstr "通过集成各种 Flask 的扩展和库,才得以实现上述许多功能. 它们包括:"
 
 #: ../../index.rst:21
 msgid "`Flask-Login <http://packages.python.org/Flask-Login/>`_"
-msgstr ""
+msgstr "`Flask-Login <http://packages.python.org/Flask-Login/>`_"
 
 #: ../../index.rst:22
 msgid "`Flask-Mail <http://packages.python.org/Flask-Mail/>`_"
-msgstr ""
+msgstr "`Flask-Mail <http://packages.python.org/Flask-Mail/>`_"
 
 #: ../../index.rst:23
 msgid "`Flask-Principal <http://packages.python.org/Flask-Principal/>`_"
-msgstr ""
+msgstr "`Flask-Principal <http://packages.python.org/Flask-Principal/>`_"
 
 #: ../../index.rst:24
 msgid "`Flask-Script <http://packages.python.org/Flask-Script/>`_"
-msgstr ""
+msgstr "`Flask-Script <http://packages.python.org/Flask-Script/>`_"
 
 #: ../../index.rst:25
 msgid "`Flask-WTF <http://packages.python.org/Flask-WTF/>`_"
-msgstr ""
+msgstr "`Flask-WTF <http://packages.python.org/Flask-WTF/>`_"
 
 #: ../../index.rst:26
 msgid "`itsdangerous <http://packages.python.org/itsdangerous/>`_"
-msgstr ""
+msgstr "`itsdangerous <http://packages.python.org/itsdangerous/>`_"
 
 #: ../../index.rst:27
 msgid "`passlib <http://packages.python.org/passlib/>`_"
-msgstr ""
+msgstr "`passlib <http://packages.python.org/passlib/>`_"
 
 #: ../../index.rst:29
 msgid ""
@@ -108,20 +111,22 @@ msgid ""
 "database connections and model definitions. Flask-Security supports the "
 "following Flask extensions out of the box for data persistence:"
 msgstr ""
+"此外,我们假定你会为你的数据库链接和模型定义使用一个通用的库. Flask-"
+"Security 开箱即用的支持下列 Flask 数据持久化扩展:"
 
 #: ../../index.rst:33
 msgid "`Flask-SQLAlchemy <http://pypi.python.org/pypi/flask-sqlalchemy/>`_"
-msgstr ""
+msgstr "`Flask-SQLAlchemy <http://pypi.python.org/pypi/flask-sqlalchemy/>`_"
 
 #: ../../index.rst:34
 msgid "`Flask-MongoEngine <http://pypi.python.org/pypi/flask-mongoengine/>`_"
 msgstr ""
+"`Flask-MongoEngine <http://pypi.python.org/pypi/flask-mongoengine/>`_"
 
 #: ../../index.rst:35
 msgid "`Flask-Peewee <http://pypi.python.org/pypi/flask-peewee/>`_"
-msgstr ""
+msgstr "`Flask-Peewee <http://pypi.python.org/pypi/flask-peewee/>`_"
 
 #: ../../contents.rst.inc:2
 msgid "Contents"
-msgstr ""
-
+msgstr "目录"

--- a/docs/locale/zh-CN/LC_MESSAGES/models.po
+++ b/docs/locale/zh-CN/LC_MESSAGES/models.po
@@ -4,23 +4,24 @@
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 1.7.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-28 10:58+0800\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"POT-Creation-Date: 2017-03-27 11:45+0800\n"
+"PO-Revision-Date: 2017-03-27 16:00+0800\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.4.0\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: zh_CN\n"
+"X-Generator: Poedit 1.8.6\n"
 
 #: ../../models.rst:2
 msgid "Models"
-msgstr ""
+msgstr "模型"
 
 #: ../../models.rst:4
 msgid ""
@@ -29,55 +30,59 @@ msgid ""
 "`Role` model. The fields on your models must follow a particular "
 "convention depending on the functionality your app requires. Aside from "
 "this, you're free to add any additional fields to your model(s) if you "
-"want. At the bare minimum your `User` and `Role` model should include the"
-" following fields:"
+"want. At the bare minimum your `User` and `Role` model should include "
+"the following fields:"
 msgstr ""
+"Flask-Security 假定你会使用诸如 SQLAlchemy, MongoEngine or Peewee 这样的"
+"库去定义包含 `User` 和 `Role` 的数据模型. 模型中的字段必须遵循一个特别的"
+"约定取决于你应用的功能需求. 除此之外,你可以随意的在你的模型中增加额外的字"
+"段,最小的 `User` 和 `Role` 模型应该包含以下字段:"
 
 #: ../../models.rst:11
 msgid "**User**"
-msgstr ""
+msgstr "**User**"
 
 #: ../../models.rst:13 ../../models.rst:20
 msgid "``id``"
-msgstr ""
+msgstr "``id``"
 
 #: ../../models.rst:14
 msgid "``email``"
-msgstr ""
+msgstr "``email``"
 
 #: ../../models.rst:15
 msgid "``password``"
-msgstr ""
+msgstr "``password``"
 
 #: ../../models.rst:16
 msgid "``active``"
-msgstr ""
+msgstr "``active``"
 
 #: ../../models.rst:18
 msgid "**Role**"
-msgstr ""
+msgstr "**Role**"
 
 #: ../../models.rst:21
 msgid "``name``"
-msgstr ""
+msgstr "``name``"
 
 #: ../../models.rst:22
 msgid "``description``"
-msgstr ""
+msgstr "``description``"
 
 #: ../../models.rst:26
 msgid "Additional Functionality"
-msgstr ""
+msgstr "附加功能"
 
 #: ../../models.rst:28
 msgid ""
 "Depending on the application's configuration, additional fields may need "
 "to be added to your `User` model."
-msgstr ""
+msgstr "根据应用配置,一些额外的字段可以根据需求加入到你的 `User` 模型."
 
 #: ../../models.rst:32
 msgid "Confirmable"
-msgstr ""
+msgstr "可验证"
 
 #: ../../models.rst:34
 msgid ""
@@ -85,14 +90,16 @@ msgid ""
 "`SECURITY_CONFIRMABLE` configuration value to `True`, your `User` model "
 "will require the following additional field:"
 msgstr ""
+"如果你通过设置应用的  `SECURITY_CONFIRMABLE` 参数为 `True` 开启了账户验"
+"证, 你的 `User` 模型将需要以下额外字段:"
 
 #: ../../models.rst:38
 msgid "``confirmed_at``"
-msgstr ""
+msgstr "``confirmed_at``"
 
 #: ../../models.rst:41
 msgid "Trackable"
-msgstr ""
+msgstr "可追踪"
 
 #: ../../models.rst:43
 msgid ""
@@ -100,24 +107,25 @@ msgid ""
 "`SECURITY_TRACKABLE` configuration value to `True`, your `User` model "
 "will require the following additional fields:"
 msgstr ""
+"如果你通过设置应用的 `SECURITY_TRACKABLE` 参数为 `True`,你的 `User` 模型"
+"将需要以下额外字段:"
 
 #: ../../models.rst:47
 msgid "``last_login_at``"
-msgstr ""
+msgstr "``last_login_at``"
 
 #: ../../models.rst:48
 msgid "``current_login_at``"
-msgstr ""
+msgstr "``current_login_at``"
 
 #: ../../models.rst:49
 msgid "``last_login_ip``"
-msgstr ""
+msgstr "``last_login_ip``"
 
 #: ../../models.rst:50
 msgid "``current_login_ip``"
-msgstr ""
+msgstr "``current_login_ip``"
 
 #: ../../models.rst:51
 msgid "``login_count``"
-msgstr ""
-
+msgstr "``login_count``"

--- a/docs/locale/zh-CN/LC_MESSAGES/models.po
+++ b/docs/locale/zh-CN/LC_MESSAGES/models.po
@@ -1,0 +1,123 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2012, Matt Wright
+# This file is distributed under the same license as the Flask-Security
+# package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Flask-Security 1.7.5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-03-28 10:58+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.4.0\n"
+
+#: ../../models.rst:2
+msgid "Models"
+msgstr ""
+
+#: ../../models.rst:4
+msgid ""
+"Flask-Security assumes you'll be using libraries such as SQLAlchemy, "
+"MongoEngine or Peewee to define a data model that includes a `User` and "
+"`Role` model. The fields on your models must follow a particular "
+"convention depending on the functionality your app requires. Aside from "
+"this, you're free to add any additional fields to your model(s) if you "
+"want. At the bare minimum your `User` and `Role` model should include the"
+" following fields:"
+msgstr ""
+
+#: ../../models.rst:11
+msgid "**User**"
+msgstr ""
+
+#: ../../models.rst:13 ../../models.rst:20
+msgid "``id``"
+msgstr ""
+
+#: ../../models.rst:14
+msgid "``email``"
+msgstr ""
+
+#: ../../models.rst:15
+msgid "``password``"
+msgstr ""
+
+#: ../../models.rst:16
+msgid "``active``"
+msgstr ""
+
+#: ../../models.rst:18
+msgid "**Role**"
+msgstr ""
+
+#: ../../models.rst:21
+msgid "``name``"
+msgstr ""
+
+#: ../../models.rst:22
+msgid "``description``"
+msgstr ""
+
+#: ../../models.rst:26
+msgid "Additional Functionality"
+msgstr ""
+
+#: ../../models.rst:28
+msgid ""
+"Depending on the application's configuration, additional fields may need "
+"to be added to your `User` model."
+msgstr ""
+
+#: ../../models.rst:32
+msgid "Confirmable"
+msgstr ""
+
+#: ../../models.rst:34
+msgid ""
+"If you enable account confirmation by setting your application's "
+"`SECURITY_CONFIRMABLE` configuration value to `True`, your `User` model "
+"will require the following additional field:"
+msgstr ""
+
+#: ../../models.rst:38
+msgid "``confirmed_at``"
+msgstr ""
+
+#: ../../models.rst:41
+msgid "Trackable"
+msgstr ""
+
+#: ../../models.rst:43
+msgid ""
+"If you enable user tracking by setting your application's "
+"`SECURITY_TRACKABLE` configuration value to `True`, your `User` model "
+"will require the following additional fields:"
+msgstr ""
+
+#: ../../models.rst:47
+msgid "``last_login_at``"
+msgstr ""
+
+#: ../../models.rst:48
+msgid "``current_login_at``"
+msgstr ""
+
+#: ../../models.rst:49
+msgid "``last_login_ip``"
+msgstr ""
+
+#: ../../models.rst:50
+msgid "``current_login_ip``"
+msgstr ""
+
+#: ../../models.rst:51
+msgid "``login_count``"
+msgstr ""
+

--- a/docs/locale/zh-CN/LC_MESSAGES/quickstart.po
+++ b/docs/locale/zh-CN/LC_MESSAGES/quickstart.po
@@ -4,111 +4,116 @@
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 1.7.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-28 10:58+0800\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"POT-Creation-Date: 2017-03-27 11:45+0800\n"
+"PO-Revision-Date: 2017-03-28 15:15+0800\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.4.0\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: zh_CN\n"
+"X-Generator: Poedit 1.8.6\n"
 
 #: ../../quickstart.rst:2
 msgid "Quick Start"
-msgstr ""
+msgstr "快速开始"
 
 #: ../../quickstart.rst:4
 msgid "`Basic SQLAlchemy Application <#basic-sqlalchemy-application>`_"
-msgstr ""
+msgstr "`基于 SQLAlchemy 的基础应用 <#id1>`_"
 
 #: ../../quickstart.rst:5
 msgid "`Basic MongoEngine Application <#basic-mongoengine-application>`_"
-msgstr ""
+msgstr "`基于 MongoEngine 的基础应用 <#id2>`_"
 
 #: ../../quickstart.rst:6
 msgid "`Basic Peewee Application <#basic-peewee-application>`_"
-msgstr ""
+msgstr "`基于 Peewee 的基础应用 <#id3>`_"
 
 #: ../../quickstart.rst:7
 msgid "`Mail Configuration <#mail-configuration>`_"
-msgstr ""
+msgstr "`邮件配置 <#id4>`_"
 
 #: ../../quickstart.rst:10
 msgid "Basic SQLAlchemy Application"
-msgstr ""
+msgstr "基于 SQLAlchemy 的基础应用"
 
 #: ../../quickstart.rst:13
 msgid "SQLAlchemy Install requirements"
-msgstr ""
+msgstr "SQLAlchemy 依赖安装"
 
 #: ../../quickstart.rst:22
 msgid "SQLAlchemy Application"
-msgstr ""
+msgstr "SQLAlchemy 应用"
 
 #: ../../quickstart.rst:24
 msgid ""
 "The following code sample illustrates how to get started as quickly as "
 "possible using SQLAlchemy:"
-msgstr ""
+msgstr "下面的代码简单的演示了如何快速开始基于 SQLAlchemy 的应用:"
 
 #: ../../quickstart.rst:84
 msgid "Basic MongoEngine Application"
-msgstr ""
+msgstr "基于 MongoEngine 的基础应用"
 
 #: ../../quickstart.rst:87
 msgid "MongoEngine Install requirements"
-msgstr ""
+msgstr "MongoEngine 依赖安装"
 
 #: ../../quickstart.rst:95
 msgid "MongoEngine Application"
-msgstr ""
+msgstr "MongoEngine 应用"
 
 #: ../../quickstart.rst:97
 msgid ""
 "The following code sample illustrates how to get started as quickly as "
 "possible using MongoEngine:"
-msgstr ""
+msgstr "下面的代码简单的演示了如何快速开始基于 MongoEngine 的应用:"
 
 #: ../../quickstart.rst:151
 msgid "Basic Peewee Application"
-msgstr ""
+msgstr "基于 Peewee 的基础应用"
 
 #: ../../quickstart.rst:154
 msgid "Peewee Install requirements"
-msgstr ""
+msgstr "Peewee 依赖安装"
 
 #: ../../quickstart.rst:162
 msgid "Peewee Application"
-msgstr ""
+msgstr "Peewee 应用"
 
 #: ../../quickstart.rst:164
 msgid ""
 "The following code sample illustrates how to get started as quickly as "
 "possible using Peewee:"
-msgstr ""
+msgstr "下面的代码简单的演示了如何快速开始基于 Peewee 的应用:"
 
 #: ../../quickstart.rst:229
 msgid "Mail Configuration"
-msgstr ""
+msgstr "邮件配置"
 
 #: ../../quickstart.rst:231
 msgid ""
 "Flask-Security integrates with Flask-Mail to handle all email "
 "communications between user and site, so it's important to configure "
-"Flask-Mail with your email server details so Flask-Security can talk with"
-" Flask-Mail correctly."
+"Flask-Mail with your email server details so Flask-Security can talk "
+"with Flask-Mail correctly."
 msgstr ""
+"Flask-Security 集成了 Flask-Mail 去处理所有用户和网站间的通讯,\n"
+"所以将你的邮件服务器信息配置到 Flask-Mail 是很重要的.\n"
+"这样 Flask-Security 才可以和 Flask-Mail 正确的通信."
 
 #: ../../quickstart.rst:236
 msgid ""
-"The following code illustrates a basic setup, which could be added to the"
-" basic application code in the previous section::"
+"The following code illustrates a basic setup, which could be added to "
+"the basic application code in the previous section::"
 msgstr ""
+"下面的代码演示了基础的设置, 可以加入到之前的所演示的基础应用代码中使用:"
 
 #: ../../quickstart.rst:250
 msgid ""
@@ -116,4 +121,6 @@ msgid ""
 "work with your particular email server configuration, please see the "
 "`Flask-Mail documentation <http://packages.python.org/Flask-Mail/>`_."
 msgstr ""
-
+"想要了解更多原生配置选项,配置 Flask-Mail 并使其工作于你的特殊的邮件服务"
+"器,请看\n"
+"`Flask-Mail 文档 <http://packages.python.org/Flask-Mail/>`_."

--- a/docs/locale/zh-CN/LC_MESSAGES/quickstart.po
+++ b/docs/locale/zh-CN/LC_MESSAGES/quickstart.po
@@ -1,0 +1,119 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2012, Matt Wright
+# This file is distributed under the same license as the Flask-Security
+# package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Flask-Security 1.7.5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-03-28 10:58+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.4.0\n"
+
+#: ../../quickstart.rst:2
+msgid "Quick Start"
+msgstr ""
+
+#: ../../quickstart.rst:4
+msgid "`Basic SQLAlchemy Application <#basic-sqlalchemy-application>`_"
+msgstr ""
+
+#: ../../quickstart.rst:5
+msgid "`Basic MongoEngine Application <#basic-mongoengine-application>`_"
+msgstr ""
+
+#: ../../quickstart.rst:6
+msgid "`Basic Peewee Application <#basic-peewee-application>`_"
+msgstr ""
+
+#: ../../quickstart.rst:7
+msgid "`Mail Configuration <#mail-configuration>`_"
+msgstr ""
+
+#: ../../quickstart.rst:10
+msgid "Basic SQLAlchemy Application"
+msgstr ""
+
+#: ../../quickstart.rst:13
+msgid "SQLAlchemy Install requirements"
+msgstr ""
+
+#: ../../quickstart.rst:22
+msgid "SQLAlchemy Application"
+msgstr ""
+
+#: ../../quickstart.rst:24
+msgid ""
+"The following code sample illustrates how to get started as quickly as "
+"possible using SQLAlchemy:"
+msgstr ""
+
+#: ../../quickstart.rst:84
+msgid "Basic MongoEngine Application"
+msgstr ""
+
+#: ../../quickstart.rst:87
+msgid "MongoEngine Install requirements"
+msgstr ""
+
+#: ../../quickstart.rst:95
+msgid "MongoEngine Application"
+msgstr ""
+
+#: ../../quickstart.rst:97
+msgid ""
+"The following code sample illustrates how to get started as quickly as "
+"possible using MongoEngine:"
+msgstr ""
+
+#: ../../quickstart.rst:151
+msgid "Basic Peewee Application"
+msgstr ""
+
+#: ../../quickstart.rst:154
+msgid "Peewee Install requirements"
+msgstr ""
+
+#: ../../quickstart.rst:162
+msgid "Peewee Application"
+msgstr ""
+
+#: ../../quickstart.rst:164
+msgid ""
+"The following code sample illustrates how to get started as quickly as "
+"possible using Peewee:"
+msgstr ""
+
+#: ../../quickstart.rst:229
+msgid "Mail Configuration"
+msgstr ""
+
+#: ../../quickstart.rst:231
+msgid ""
+"Flask-Security integrates with Flask-Mail to handle all email "
+"communications between user and site, so it's important to configure "
+"Flask-Mail with your email server details so Flask-Security can talk with"
+" Flask-Mail correctly."
+msgstr ""
+
+#: ../../quickstart.rst:236
+msgid ""
+"The following code illustrates a basic setup, which could be added to the"
+" basic application code in the previous section::"
+msgstr ""
+
+#: ../../quickstart.rst:250
+msgid ""
+"To learn more about the various Flask-Mail settings to configure it to "
+"work with your particular email server configuration, please see the "
+"`Flask-Mail documentation <http://packages.python.org/Flask-Mail/>`_."
+msgstr ""
+


### PR DESCRIPTION
1. add i18n configs to conf.py
2. make conf.py support Python3
3. edit 3 spelling mistakes
4. add 9 .po files of Chinese translation

use following code to generate Chinese version of documents

```make -e SPHINXOPTS="-D language='zh-CN'" html```

P.S. there is a style bug (or need config?) when sphinx-build translation files, see [this issue](https://github.com/sphinx-doc/sphinx/issues/3588)