### PR TITLE
Lift restriction on bcrypt<2.0.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 Flask-SQLAlchemy>=1.0
 bcrypt>=1.0.2
-flask-mongoengine>=0.7.0,<0.7.3
+flask-mongoengine>=0.7.0
 flask-peewee>=0.6.5
 pymongo==2.8
 pytest>=2.5.2


### PR DESCRIPTION
[Passlib since version 1.6.4](https://bitbucket.org/ecollins/passlib/commits/bca2e7655aa963881ce1cb8842803abc2c836101) has worked correctly with bcrypt>=2.0.0 ([relevant issue](https://bitbucket.org/ecollins/passlib/issues/49/incompatibility-with-bcrypt-backend), [relevant issue](https://bitbucket.org/ecollins/passlib/issues/56/brcypt-support-broken-for-200)). This proposed change edits the flask-security documentation to reflect that.