### PR TITLE
fixed Flask-Login link in docs

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -129,8 +129,8 @@ Run ``flask --help`` and look for users and roles.
 
 
 .. _Click: http://packages.python.org/Click/
-.. _Flask-Login: http://packages.python.org/Flask-Login/
-.. _alternative token: http://packages.python.org/Flask-Login/#alternative-tokens
+.. _Flask-Login: https://flask-login.readthedocs.org/en/latest/
+.. _alternative token: https://flask-login.readthedocs.io/en/latest/#alternative-tokens
 .. _Flask-Principal: http://packages.python.org/Flask-Principal/
 .. _documentation on this topic: http://packages.python.org/Flask-Principal/#granular-resource-protection
 .. _passlib: http://packages.python.org/passlib/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ Flask application. They include:
 Many of these features are made possible by integrating various Flask extensions
 and libraries. They include:
 
-1. `Flask-Login <http://packages.python.org/Flask-Login/>`_
+1. `Flask-Login <https://flask-login.readthedocs.org/en/latest/>`_
 2. `Flask-Mail <http://packages.python.org/Flask-Mail/>`_
 3. `Flask-Principal <http://packages.python.org/Flask-Principal/>`_
 4. `Flask-WTF <http://packages.python.org/Flask-WTF/>`_


### PR DESCRIPTION
The links to Flask-Login were outdated in the documentation.