### PR TITLE
Use gettext instead of lazy_gettext so Flask's flash doesn't error

### DIFF
--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -324,7 +324,7 @@ def get_config(app):
 
 def get_message(key, **kwargs):
     rv = config_value('MSG_' + key)
-    return _security.i18n_domain.lazy_gettext(rv[0], **kwargs), rv[1]
+    return _security.i18n_domain.gettext(rv[0], **kwargs), rv[1]
 
 
 def config_value(key, app=None, default=None):


### PR DESCRIPTION
I'm getting this exception when registering a user (after upgrading to latest master of Flask-Security-Fork, that includes fully localized messages):

    127.0.0.1 - - [06/May/2017 08:44:01] "POST /register/ HTTP/1.1" 500 -
    Traceback (most recent call last):
      File "/home/jaza/wsgi/archiunit/env/lib/python3.5/site-packages/flask/app.py", line 2000, in __call__
        return self.wsgi_app(environ, start_response)
      File "/home/jaza/wsgi/archiunit/env/lib/python3.5/site-packages/flask/app.py", line 1991, in wsgi_app
        response = self.make_response(self.handle_exception(e))
      File "/home/jaza/wsgi/archiunit/env/lib/python3.5/site-packages/flask/app.py", line 1567, in handle_exception
        reraise(exc_type, exc_value, tb)
      File "/home/jaza/wsgi/archiunit/env/lib/python3.5/site-packages/flask/_compat.py", line 33, in reraise
        raise value
      File "/home/jaza/wsgi/archiunit/env/lib/python3.5/site-packages/flask/app.py", line 1988, in wsgi_app
        response = self.full_dispatch_request()
      File "/home/jaza/wsgi/archiunit/env/lib/python3.5/site-packages/flask/app.py", line 1643, in full_dispatch_request
        response = self.process_response(response)
      File "/home/jaza/wsgi/archiunit/env/lib/python3.5/site-packages/flask/app.py", line 1864, in process_response
        self.save_session(ctx.session, response)
      File "/home/jaza/wsgi/archiunit/env/lib/python3.5/site-packages/flask/app.py", line 926, in save_session
        return self.session_interface.save_session(self, session, response)
      File "/home/jaza/wsgi/archiunit/env/lib/python3.5/site-packages/flask/sessions.py", line 359, in save_session
        val = self.get_signing_serializer(app).dumps(dict(session))
      File "/home/jaza/wsgi/archiunit/env/lib/python3.5/site-packages/itsdangerous.py", line 565, in dumps
        payload = want_bytes(self.dump_payload(obj))
      File "/home/jaza/wsgi/archiunit/env/lib/python3.5/site-packages/itsdangerous.py", line 847, in dump_payload
        json = super(URLSafeSerializerMixin, self).dump_payload(obj)
      File "/home/jaza/wsgi/archiunit/env/lib/python3.5/site-packages/itsdangerous.py", line 550, in dump_payload
        return want_bytes(self.serializer.dumps(obj))
      File "/home/jaza/wsgi/archiunit/env/lib/python3.5/site-packages/flask/sessions.py", line 85, in dumps
        return json.dumps(_tag(value), separators=(',', ':'))
      File "/home/jaza/wsgi/archiunit/env/lib/python3.5/site-packages/flask/json.py", line 126, in dumps
        rv = _json.dumps(obj, **kwargs)
      File "/usr/lib/python3.5/json/__init__.py", line 237, in dumps
        **kw).encode(obj)
      File "/usr/lib/python3.5/json/encoder.py", line 198, in encode
        chunks = self.iterencode(o, _one_shot=True)
      File "/usr/lib/python3.5/json/encoder.py", line 256, in iterencode
        return _iterencode(o, 0)
      File "/home/jaza/wsgi/archiunit/env/lib/python3.5/site-packages/flask/json.py", line 83, in default
        return _json.JSONEncoder.default(self, o)
      File "/usr/lib/python3.5/json/encoder.py", line 179, in default
        raise TypeError(repr(o) + " is not JSON serializable")
    TypeError: l'Thank you. Confirmation instructions have been sent to test123@test.com.' is not JSON serializable

Related to https://github.com/maxcountryman/flask-login/issues/203 .

Changing Flask-Security's `get_message` to use `gettext` instead of `lazy_gettext` fixes it for me.

Originally submitted this PR to the fork at https://github.com/inveniosoftware/flask-security-fork/pull/38 , submitting it to the main repo now instead.