### PR TITLE
core: set localize_callback for login manager

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -30,8 +30,8 @@ from .forms import ChangePasswordForm, ConfirmRegisterForm, \
     ForgotPasswordForm, LoginForm, PasswordlessLoginForm, RegisterForm, \
     ResetPasswordForm, SendConfirmationForm
 from .utils import config_value as cv
-from .utils import _, get_config, hash_data, string_types, url_for_security, \
-    verify_hash
+from .utils import _, get_config, hash_data, localize_callback, string_types, \
+    url_for_security, verify_hash
 from .views import create_blueprint
 
 # Convenient references
@@ -259,6 +259,7 @@ def _on_identity_loaded(sender, identity):
 def _get_login_manager(app, anonymous_user):
     lm = LoginManager()
     lm.anonymous_user = anonymous_user or AnonymousUser
+    lm.localize_callback = localize_callback
     lm.login_view = '%s.login' % cv('BLUEPRINT_NAME', app=app)
     lm.user_loader(_user_loader)
     lm.request_loader(_request_loader)

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -44,6 +44,8 @@ _pwd_context = LocalProxy(lambda: _security.pwd_context)
 
 _hashing_context = LocalProxy(lambda: _security.hashing_context)
 
+localize_callback = LocalProxy(lambda: _security.i18n_domain.gettext)
+
 PY3 = sys.version_info[0] == 3
 
 if PY3:  # pragma: no cover
@@ -324,7 +326,7 @@ def get_config(app):
 
 def get_message(key, **kwargs):
     rv = config_value('MSG_' + key)
-    return _security.i18n_domain.gettext(rv[0], **kwargs), rv[1]
+    return localize_callback(rv[0], **kwargs), rv[1]
 
 
 def config_value(key, app=None, default=None):


### PR DESCRIPTION
Defines `localize_callback` proxy to I18N domain stored in the extension
state object.  (closes #621)