### PR TITLE
Fixing the different possibilities for the register form.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -180,6 +180,8 @@ Feature Flags
                           instructions. The URL for this endpoint is specified
                           by the ``SECURITY_CONFIRM_URL`` configuration option.
                           Defaults to ``False``.
+``SECURITY_RETYPABLE``    Specifies if users have to retype/confirm their 
+                          password when registering. Defaults to ``False``.
 ``SECURITY_REGISTERABLE`` Specifies if Flask-Security should create a user
                           registration endpoint. The URL for this endpoint is
                           specified by the ``SECURITY_REGISTER_URL``

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -68,7 +68,9 @@ Forms
 
 All forms can be overridden. For each form used, you can specify a
 replacement class. This allows you to add extra fields to the
-register form or override validators::
+register form or override validators, make sure to inherit from the
+correct class when you have set SECURITY_CONFIRMABLE and/or 
+SECURITY_RETYPABLE to ``True``::
 
     from flask_security.forms import RegisterForm
 
@@ -78,6 +80,18 @@ register form or override validators::
 
     security = Security(app, user_datastore,
              register_form=ExtendedRegisterForm)
+
+Another example with SECURITY_CONFIRMABLE and 
+SECURITY_RETYPABLE set to ``True``.
+
+    from flask_security.forms import ConfirmRetypeRegisterForm
+
+    class ExtendedRegisterForm(ConfirmRetypeRegisterForm):
+        first_name = StringField('First Name', [Required()])
+        last_name = StringField('Last Name', [Required()])
+
+    security = Security(app, user_datastore,
+             cnfrm_retyp_register_form=ExtendedRegisterForm)
 
 For the ``register_form`` and ``confirm_register_form``, each field is
 passed to the user model (as kwargs) when a user is created. In the
@@ -96,6 +110,8 @@ The following is a list of all the available form overrides:
 * ``login_form``: Login form
 * ``confirm_register_form``: Confirmable register form
 * ``register_form``: Register form
+* ``retype_register_form``: Register form with confirm password field
+* ``cnfrm_retyp_register_form: Confirm registration + confirm password field
 * ``forgot_password_form``: Forgot password form
 * ``reset_password_form``: Reset password form
 * ``change_password_form``: Change password form

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -27,7 +27,8 @@ from werkzeug.local import LocalProxy
 
 from .forms import ChangePasswordForm, ConfirmRegisterForm, \
     ForgotPasswordForm, LoginForm, PasswordlessLoginForm, RegisterForm, \
-    ResetPasswordForm, SendConfirmationForm
+    RetypeRegisterForm, ConfirmRetypeRegisterForm, ResetPasswordForm, \
+    SendConfirmationForm
 from .utils import config_value as cv
 from .utils import _, get_config, hash_data, localize_callback, string_types, \
     url_for_security, verify_hash
@@ -71,6 +72,7 @@ _default_config = {
     'SEND_CONFIRMATION_TEMPLATE': 'security/send_confirmation.html',
     'SEND_LOGIN_TEMPLATE': 'security/send_login.html',
     'CONFIRMABLE': False,
+    'RETYPABLE': False,
     'REGISTERABLE': False,
     'RECOVERABLE': False,
     'TRACKABLE': False,
@@ -208,6 +210,8 @@ _default_messages = {
 _default_forms = {
     'login_form': LoginForm,
     'confirm_register_form': ConfirmRegisterForm,
+    'retype_register_form': RetypeRegisterForm,
+    'cnfrm_retyp_register_form': ConfirmRetypeRegisterForm,
     'register_form': RegisterForm,
     'forgot_password_form': ForgotPasswordForm,
     'reset_password_form': ResetPasswordForm,
@@ -473,7 +477,8 @@ class Security(object):
                  register_form=None, forgot_password_form=None,
                  reset_password_form=None, change_password_form=None,
                  send_confirmation_form=None, passwordless_login_form=None,
-                 anonymous_user=None):
+                 anonymous_user=None, retype_register_form=None,
+                 cnfrm_retyp_register_form=None):
         """Initializes the Flask-Security extension for the specified
         application and datastore implentation.
 
@@ -501,7 +506,10 @@ class Security(object):
                            change_password_form=change_password_form,
                            send_confirmation_form=send_confirmation_form,
                            passwordless_login_form=passwordless_login_form,
-                           anonymous_user=anonymous_user)
+                           anonymous_user=anonymous_user,
+                           retype_register_form=retype_register_form,
+                           cnfrm_retyp_register_form=cnfrm_retyp_register_form
+                          )
 
         if register_blueprint:
             app.register_blueprint(create_blueprint(state, __name__))

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -250,15 +250,24 @@ class LoginForm(Form, NextFormMixin):
         return True
 
 
-class ConfirmRegisterForm(Form, RegisterFormMixin,
-                          UniqueEmailFormMixin, NewPasswordFormMixin):
+class RegisterForm(Form, RegisterFormMixin, UniqueEmailFormMixin, NewPasswordFormMixin, NextFormMixin):
     pass
 
-
-class RegisterForm(ConfirmRegisterForm, PasswordConfirmFormMixin,
-                   NextFormMixin):
+class ConfirmRegisterForm(RegisterForm):
     def __init__(self, *args, **kwargs):
-        super(RegisterForm, self).__init__(*args, **kwargs)
+        super(ConfirmRegisterForm, self).__init__(*args, **kwargs)
+        if not self.next.data:
+            self.next.data = request.args.get('next', '')
+
+class RetypeRegisterForm(RegisterForm, PasswordConfirmFormMixin):
+    def __init__(self, *args, **kwargs):
+        super(RetypeRegisterForm, self).__init__(*args, **kwargs)
+        if not self.next.data:
+            self.next.data = request.args.get('next', '')
+
+class ConfirmRetypeRegisterForm(RegisterForm, PasswordConfirmFormMixin):
+    def __init__(self, *args, **kwargs):
+        super(ConfirmRetypeRegisterForm, self).__init__(*args, **kwargs)
         if not self.next.data:
             self.next.data = request.args.get('next', '')
 

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -102,13 +102,12 @@ def logout():
 def register():
     """View function which handles a registration request."""
 
-    if _security.confirmable or request.json:
+    if (_security.confirmable and _security.retypable is False) or request.json:
         form_class = _security.confirm_register_form
-    else:
-        form_class = _security.register_form
-
-    if request.json:
-        form_data = MultiDict(request.json)
+    elif _security.confirmable is False and _security.retypable:
+        form_class = _security.retype_register_form
+    elif _security.confirmable and _security.retypable:
+        form_class = _security.confirm_retype_register_form
     else:
         form_data = request.form
 


### PR DESCRIPTION
Fix for issues
https://github.com/mattupstate/flask-security/issues/601
https://github.com/mattupstate/flask-security/issues/580

Adds a new flag: SECURITY_RETYPABLE which allows you to specify
if users have to confirm(retype) their password or not when registering.

Now you have four different combinations of possible register forms.

CONFIRMABLE: False, RETYPABLE: False => RegisterForm
CONFIRMABLE: True, RETYPABLE: False  => ConfirmRegisterForm
CONFIRMABLE: False, RETYPABLE: True  => RetypeRegisterForm
CONFIRMABLE: True, RETYPABLE: True   => ConfirmRetypeRegisterForm

Only when using the API it will default to ConfirmRegisterForm as before.