### PR TITLE
Do not use strip() to compare passwords in flask_security.forms.ChangePasswordForm

### DIFF
--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -291,7 +291,7 @@ class ChangePasswordForm(Form, PasswordFormMixin):
         if not verify_and_update_password(self.password.data, current_user):
             self.password.errors.append(get_message('INVALID_PASSWORD')[0])
             return False
-        if self.password.data.strip() == self.new_password.data.strip():
+        if self.password.data == self.new_password.data:
             self.password.errors.append(get_message('PASSWORD_IS_THE_SAME')[0])
             return False
         return True

--- a/tests/test_changeable.py
+++ b/tests/test_changeable.py
@@ -71,6 +71,14 @@ def test_recoverable_flag(app, client, get_message):
     }, follow_redirects=True)
     assert get_message('PASSWORD_IS_THE_SAME') in response.data
 
+    # Test leading & trailing whitespace not stripped
+    response = client.post('/change', data={
+        'password': 'password',
+        'new_password': '      password      ',
+        'new_password_confirm': '      password      '
+    }, follow_redirects=True)
+    assert get_message('PASSWORD_CHANGE') in response.data
+
     # Test successful submit sends email notification
     with app.mail.record_messages() as outbox:
         response = client.post('/change', data={

--- a/tests/test_changeable.py
+++ b/tests/test_changeable.py
@@ -71,14 +71,6 @@ def test_recoverable_flag(app, client, get_message):
     }, follow_redirects=True)
     assert get_message('PASSWORD_IS_THE_SAME') in response.data
 
-    # Test leading & trailing whitespace not stripped
-    response = client.post('/change', data={
-        'password': 'password',
-        'new_password': '      password      ',
-        'new_password_confirm': '      password      '
-    }, follow_redirects=True)
-    assert get_message('PASSWORD_CHANGE') in response.data
-
     # Test successful submit sends email notification
     with app.mail.record_messages() as outbox:
         response = client.post('/change', data={
@@ -93,8 +85,17 @@ def test_recoverable_flag(app, client, get_message):
     assert len(outbox) == 1
     assert "Your password has been changed" in outbox[0].html
 
+    # Test leading & trailing whitespace not stripped
+    response = client.post('/change', data={
+        'password': 'newpassword',
+        'new_password': '      newpassword      ',
+        'new_password_confirm': '      newpassword      '
+    }, follow_redirects=True)
+    assert get_message('PASSWORD_CHANGE') in response.data
+
     # Test JSON
-    data = ('{"password": "newpassword", "new_password": "newpassword2", '
+    data = ('{"password": "      newpassword      ", '
+            '"new_password": "newpassword2", '
             '"new_password_confirm": "newpassword2"}')
     response = client.post(
         '/change',


### PR DESCRIPTION
**Problem**
In the password change form (`flask_security.forms.ChangePasswordForm`), `strip()` is used to compare old and new passwords. However, whitespace is an accepted part of a password (as long as it's accompanied by other characters). For example, '     a' (six leading spaces) and 'a     ' (six trailing spaces) are two different and both *valid* passwords. Indeed, Flask-Security allows for both as valid passwords to be used, and they are not interchangeable on login. However, because the `strip()` is currently being done, on the password change form, you incorrectly get the message that the two distinct passwords are the same.

**Solution**
`strip()` is no longer used to compare if an old password and a new password are the same.

**Miscellanea**
As for the philosophical argument of whether you *should* do whitespace stripping on passwords, I'm of the camp that you *should not*. Similar sentiments can be found [here](http://stackoverflow.com/a/7240898) and [here](https://ux.stackexchange.com/a/8011), though these are not at all authoritative sources. 

However, the above argument doesn't matter as much here, since Flask-Security does take its own stance already &ndash; not to strip whitespace on passwords. The stripping does not occur on registration, nor on login. To follow suit, it should not be done in the password change form.