### PR TITLE
`csrf_enabled` deprecation fix

### DIFF
--- a/flask_security/cli.py
+++ b/flask_security/cli.py
@@ -60,7 +60,7 @@ def users_create(identity, password, active):
     kwargs.update(**{'password': password, 'active': 'y' if active else ''})
 
     form = _security.confirm_register_form(
-        MultiDict(kwargs), csrf_enabled=False
+        MultiDict(kwargs), meta={'csrf': False}
     )
 
     if form.validate():

--- a/flask_security/script.py
+++ b/flask_security/script.py
@@ -62,7 +62,7 @@ class CreateUserCommand(Command):
         from flask_security.forms import ConfirmRegisterForm
         from werkzeug.datastructures import MultiDict
 
-        form = ConfirmRegisterForm(MultiDict(kwargs), csrf_enabled=False)
+        form = ConfirmRegisterForm(MultiDict(kwargs), meta={'csrf': False})
 
         if form.validate():
             kwargs['password'] = hash_password(kwargs['password'])


### PR DESCRIPTION
The keyarg `csrf_enabled` is deprecated in `flask-wtf`. This PR switches to `meta={'csrf': False}` as advised here: https://github.com/lepture/flask-wtf/blob/master/flask_wtf/form.py#L81