### PR TITLE
Fix AttributeError in _request_loader

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -228,7 +228,8 @@ def _request_loader(request):
     token = request.args.get(args_key, header_token)
     if request.is_json:
         data = request.get_json(silent=True) or {}
-        token = data.get(args_key, token)
+        if isinstance(data, dict):
+            token = data.get(args_key, token)
 
     try:
         data = _security.remember_token_serializer.loads(


### PR DESCRIPTION
Similar to [PR #366 ](https://github.com/mattupstate/flask-security/pull/366) fixed _request_loader to be able to receive arbitrary jsons (not only dict). Currently if json is not dict server sends 500