### PR TITLE
Fix timing attack on login form

### DIFF
--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -20,9 +20,9 @@ from wtforms import BooleanField, Field, HiddenField, PasswordField, \
     StringField, SubmitField, ValidationError, validators
 
 from .confirmable import requires_confirmation
-from .utils import _, _datastore, config_value, get_message, \
-    localize_callback, url_for_security, validate_redirect_url, \
-    verify_and_update_password, encrypt_password
+from .utils import _, _datastore, config_value, encrypt_password, \
+    get_message, localize_callback, url_for_security, validate_redirect_url, \
+    verify_and_update_password
 
 lazy_gettext = make_lazy_gettext(lambda: localize_callback)
 

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -22,7 +22,7 @@ from wtforms import BooleanField, Field, HiddenField, PasswordField, \
 from .confirmable import requires_confirmation
 from .utils import _, _datastore, config_value, get_message, \
     localize_callback, url_for_security, validate_redirect_url, \
-    verify_and_update_password
+    verify_and_update_password, encrypt_password
 
 lazy_gettext = make_lazy_gettext(lambda: localize_callback)
 
@@ -234,9 +234,13 @@ class LoginForm(Form, NextFormMixin):
 
         if self.user is None:
             self.email.errors.append(get_message('USER_DOES_NOT_EXIST')[0])
+            # Reduce timing variation between existing and non-existung users
+            encrypt_password(self.password.data)
             return False
         if not self.user.password:
             self.password.errors.append(get_message('PASSWORD_NOT_SET')[0])
+            # Reduce timing variation between existing and non-existung users
+            encrypt_password(self.password.data)
             return False
         if not verify_and_update_password(self.password.data, self.user):
             self.password.errors.append(get_message('INVALID_PASSWORD')[0])

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -20,8 +20,8 @@ from wtforms import BooleanField, Field, HiddenField, PasswordField, \
     StringField, SubmitField, ValidationError, validators
 
 from .confirmable import requires_confirmation
-from .utils import _, _datastore, config_value, encrypt_password, \
-    get_message, localize_callback, url_for_security, validate_redirect_url, \
+from .utils import _, _datastore, config_value, get_message, hash_password, \
+    localize_callback, url_for_security, validate_redirect_url, \
     verify_and_update_password
 
 lazy_gettext = make_lazy_gettext(lambda: localize_callback)
@@ -235,12 +235,12 @@ class LoginForm(Form, NextFormMixin):
         if self.user is None:
             self.email.errors.append(get_message('USER_DOES_NOT_EXIST')[0])
             # Reduce timing variation between existing and non-existung users
-            encrypt_password(self.password.data)
+            hash_password(self.password.data)
             return False
         if not self.user.password:
             self.password.errors.append(get_message('PASSWORD_NOT_SET')[0])
             # Reduce timing variation between existing and non-existung users
-            encrypt_password(self.password.data)
+            hash_password(self.password.data)
             return False
         if not verify_and_update_password(self.password.data, self.user):
             self.password.errors.append(get_message('INVALID_PASSWORD')[0])


### PR DESCRIPTION
As detailed in #357 the time it takes to process a login request is
considerably less if the user specified doesn't exist than if the
password is incorrect. This can be used as a user enumeration attack,
even if the login error messages were customized to avoid this.

I fixed it by increasing the response time of a non-existing user
request by hashing the given password anyway (if using good
password hashing algorithm this is what takes a relatively
large amount of time and makes the attack possibly)

Without the fix:
```bash
$ time curl 'http://localhost:5000/login' --data 'next=&email=not%40existing.com&password=12312312312&next=&submit=Login' -s> /dev/null
curl 'http://localhost:5000/login' --data  -s > /dev/null  0,02s user 0,00s system 43% cpu 0,037 total
$ time curl 'http://localhost:5000/login' --data 'next=&email=existing%40gmail.com&password=12312312312&next=&submit=Login' -s> /dev/null
curl 'http://localhost:5000/login' --data  -s > /dev/null  0,01s user 0,01s system 4% cpu 0,401 total
```

With the fix:
```bash
$ time curl 'http://localhost:5000/login' --data 'next=&email=not%40existing.com&password=12312312312&next=&submit=Login' -s> /dev/null
curl 'http://localhost:5000/login' --data  -s > /dev/null  0,01s user 0,01s system 4% cpu 0,402 total
$ time curl 'http://localhost:5000/login' --data 'next=&email=existing%40gmail.com&password=12312312312&next=&submit=Login' -s> /dev/null
curl 'http://localhost:5000/login' --data  -s > /dev/null  0,01s user 0,01s system 4% cpu 0,401 total
```