### PR TITLE
fix issue #681

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -228,6 +228,8 @@ def _request_loader(request):
     token = request.args.get(args_key, header_token)
     if request.is_json:
         data = request.get_json(silent=True) or {}
+        if isinstance(data, list):
+            data = {}        
         token = data.get(args_key, token)
 
     try:

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -229,7 +229,7 @@ def _request_loader(request):
     if request.is_json:
         data = request.get_json(silent=True) or {}
         if isinstance(data, list):
-            data = {}        
+            data = {}
         token = data.get(args_key, token)
 
     try:


### PR DESCRIPTION
If data is a py `list` we change it to a empty `dict`. So that the get attribute is available. 

https://github.com/mattupstate/flask-security/issues/681