### PR TITLE
Fix adding roles when identity is username

### DIFF
--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -118,7 +118,8 @@ class UserDatastore(object):
 
     def _prepare_role_modify_args(self, user, role):
         if isinstance(user, string_types):
-            user = self.find_user(email=user)
+            user_kwargs = {attr: user for attr in get_identity_attributes()}
+            user = self.find_user(**user_kwargs)
         if isinstance(role, string_types):
             role = self.find_role(role)
         return user, role


### PR DESCRIPTION
This resolves a bug that manifests under the following conditions:

* `app.config["SECURITY_USER_IDENTITY_ATTRIBUTES"] = ["username"]`
* SQLAlchemy datastore
* User model has no "email" field
* `flask roles add <username> <role>`

Traceback:
```
$ flask roles add singingwolfboy superuser
Traceback (most recent call last):
  File "/Users/singingwolfboy/.virtualenvs/bradley/lib/python3.6/site-packages/sqlalchemy/orm/base.py", line 379, in _entity_descriptor
    return getattr(entity, key)
AttributeError: type object 'User' has no attribute 'email'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/singingwolfboy/.virtualenvs/bradley/bin/flask", line 11, in <module>
    sys.exit(main())
  File "/Users/singingwolfboy/.virtualenvs/bradley/lib/python3.6/site-packages/flask/cli.py", line 514, in main
    cli.main(args=args, prog_name=name)
  File "/Users/singingwolfboy/.virtualenvs/bradley/lib/python3.6/site-packages/flask/cli.py", line 381, in main
    return AppGroup.main(self, *args, **kwargs)
  File "/Users/singingwolfboy/.virtualenvs/bradley/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/singingwolfboy/.virtualenvs/bradley/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/singingwolfboy/.virtualenvs/bradley/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/singingwolfboy/.virtualenvs/bradley/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/singingwolfboy/.virtualenvs/bradley/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/singingwolfboy/.virtualenvs/bradley/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/singingwolfboy/.virtualenvs/bradley/lib/python3.6/site-packages/flask/cli.py", line 257, in decorator
    return __ctx.invoke(f, *args, **kwargs)
  File "/Users/singingwolfboy/.virtualenvs/bradley/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/singingwolfboy/.virtualenvs/bradley/lib/python3.6/site-packages/flask_security/cli.py", line 36, in wrapper
    fn(*args, **kwargs)
  File "/Users/singingwolfboy/.virtualenvs/bradley/lib/python3.6/site-packages/flask_security/cli.py", line 95, in roles_add
    user, role = _datastore._prepare_role_modify_args(user, role)
  File "/Users/singingwolfboy/.virtualenvs/bradley/lib/python3.6/site-packages/flask_security/datastore.py", line 121, in _prepare_role_modify_args
    user = self.find_user(email=user)
  File "/Users/singingwolfboy/.virtualenvs/bradley/lib/python3.6/site-packages/flask_security/datastore.py", line 254, in find_user
    return self.user_model.query.filter_by(**kwargs).first()
  File "/Users/singingwolfboy/.virtualenvs/bradley/lib/python3.6/site-packages/sqlalchemy/orm/query.py", line 1562, in filter_by
    for key, value in kwargs.items()]
  File "/Users/singingwolfboy/.virtualenvs/bradley/lib/python3.6/site-packages/sqlalchemy/orm/query.py", line 1562, in <listcomp>
    for key, value in kwargs.items()]
  File "/Users/singingwolfboy/.virtualenvs/bradley/lib/python3.6/site-packages/sqlalchemy/orm/base.py", line 383, in _entity_descriptor
    (description, key)
sqlalchemy.exc.InvalidRequestError: Entity '<class 'bradley.models.auth.User'>' has no property 'email'
```

I'm not sure what's the best way to write a test for this. None of the automated tests seem to handle the case where we have a nonstandard identity attribute.


