### PR TITLE
Documentation/Quickstart: Fix SQLAlchemy app example for missing render method and adding salt

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -108,7 +108,6 @@ and models.py. You can also do the models a folder and spread your tables there.
 
 - app.py ::
 
-    import uuid
     from flask import Flask, render_template_string
     from flask_security import Security, current_user, login_required, \
          SQLAlchemySessionUserDatastore
@@ -120,7 +119,7 @@ and models.py. You can also do the models a folder and spread your tables there.
     app.config['DEBUG'] = True
     app.config['SECRET_KEY'] = 'super-secret'
     # Bcrypt is set as default SECURITY_PASSWORD_HASH, which requires a salt
-    app.config['SECURITY_PASSWORD_SALT'] = uuid.uuid4().hex
+    app.config['SECURITY_PASSWORD_SALT'] = 'super-secret-random-salt'
 
     # Setup Flask-Security
     user_datastore = SQLAlchemySessionUserDatastore(db_session,

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -108,8 +108,9 @@ and models.py. You can also do the models a folder and spread your tables there.
 
 - app.py ::
 
-    from flask import Flask
-    from flask_security import Security, login_required, \
+    import uuid
+    from flask import Flask, render_template_string
+    from flask_security import Security, current_user, login_required, \
          SQLAlchemySessionUserDatastore
     from database import db_session, init_db
     from models import User, Role
@@ -118,6 +119,8 @@ and models.py. You can also do the models a folder and spread your tables there.
     app = Flask(__name__)
     app.config['DEBUG'] = True
     app.config['SECRET_KEY'] = 'super-secret'
+    # Bcrypt is set as default SECURITY_PASSWORD_HASH, which requires a salt
+    app.config['SECURITY_PASSWORD_SALT'] = uuid.uuid4().hex
 
     # Setup Flask-Security
     user_datastore = SQLAlchemySessionUserDatastore(db_session,
@@ -135,7 +138,7 @@ and models.py. You can also do the models a folder and spread your tables there.
     @app.route('/')
     @login_required
     def home():
-        return render('Here you go!')
+        return render_template_string('Hello {{email}} !', email=current_user.email)
 
     if __name__ == '__main__':
         app.run()


### PR DESCRIPTION
Details:
* Fix exception raised when 'SECURITY_PASSWORD_SALT' is not set, as 'SECURITY_PASSWORD_HASH' [bcrypt] requires it which is default.
* render method is not found, replaced the same with render_template_string.
* render_template_string is utilised to show an example of usage of current user retaining the previous use case.