### PR TITLE
utils: fix incorrect email sender type

### DIFF
--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -383,8 +383,12 @@ def send_mail(subject, recipient, template, **context):
     context.setdefault('security', _security)
     context.update(_security._run_ctx_processor('mail'))
 
+    sender = _security.email_sender
+    if isinstance(sender, LocalProxy):
+        sender = sender._get_current_object()
+
     msg = Message(subject,
-                  sender=_security.email_sender,
+                  sender=sender,
                   recipients=[recipient])
 
     ctx = ('security/email', template)


### PR DESCRIPTION
* Fixes error when sending emails using Flask-Mail, without setting the
  SECURITY_EMAIL_SENDER (closes #685).