### PR TITLE
Fix formatting for Basic SQLAlchemy section

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -106,7 +106,7 @@ possible using `SQLAlchemy in a declarative way
 We are gonna split the application at least in three files: app.py, database.py
 and models.py. You can also do the models a folder and spread your tables there.
 
-- app.py:
+- app.py
 
 ::
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -106,8 +106,10 @@ possible using `SQLAlchemy in a declarative way
 We are gonna split the application at least in three files: app.py, database.py
 and models.py. You can also do the models a folder and spread your tables there.
 
-- app.py
+- app.py:
+
 ::
+
     from flask import Flask
     from flask_security import Security, login_required, \
          SQLAlchemySessionUserDatastore
@@ -141,7 +143,9 @@ and models.py. You can also do the models a folder and spread your tables there.
         app.run()
 
 - database.py
+
 ::
+
     from sqlalchemy import create_engine
     from sqlalchemy.orm import scoped_session, sessionmaker
     from sqlalchemy.ext.declarative import declarative_base
@@ -162,7 +166,9 @@ and models.py. You can also do the models a folder and spread your tables there.
         Base.metadata.create_all(bind=engine)
 
 - models.py
+
 ::
+
     from database import Base
     from flask_security import UserMixin, RoleMixin
     from sqlalchemy import create_engine


### PR DESCRIPTION
The current version is not formatting the code blocks as it should, it is shown as normal text: https://flask-security.readthedocs.io/en/latest/quickstart.html#id2