### PR TITLE
Making sure we pass the sender address in send_mail() as a string, no…

### DIFF
--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -384,7 +384,7 @@ def send_mail(subject, recipient, template, **context):
     context.update(_security._run_ctx_processor('mail'))
 
     msg = Message(subject,
-                  sender=_security.email_sender,
+                  sender=str(_security.email_sender),
                   recipients=[recipient])
 
     ctx = ('security/email', template)


### PR DESCRIPTION
…t a LocalProxy instance. Fixes #693 https://github.com/mattupstate/flask-security/issues/693
