### PR TITLE
bugfix: support application factory pattern

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -478,20 +478,15 @@ class Security(object):
         self.app = app
         self._datastore = datastore
         self._register_blueprint = register_blueprint
-        self._kwargs = dict(login_form=None,
-                            register_form=None,
-                            confirm_register_form=None,
-                            forgot_password_form=None,
-                            reset_password_form=None,
-                            change_password_form=None,
-                            send_confirmation_form=None,
-                            passwordless_login_form=None,
-                            anonymous_user=None)
-        self._kwargs.update(kwargs)
+        self._kwargs = kwargs
 
         self._state = None  # set by init_app
         if app is not None and datastore is not None:
-            self._state = self.init_app(app, datastore, **self._kwargs)
+            self._state = self.init_app(
+                app,
+                datastore,
+                register_blueprint=register_blueprint,
+                **kwargs)
 
     def init_app(self, app, datastore=None, register_blueprint=None, **kwargs):
         """Initializes the Flask-Security extension for the specified
@@ -502,11 +497,15 @@ class Security(object):
         :param register_blueprint: to register the Security blueprint or not.
         """
         self.app = app
+
         if datastore is None:
             datastore = self._datastore
+
         if register_blueprint is None:
             register_blueprint = self._register_blueprint
-        self._kwargs.update(kwargs)
+
+        for key, value in self._kwargs.items():
+            kwargs.setdefault(key, value)
 
         for key, value in _default_config.items():
             app.config.setdefault('SECURITY_' + key, value)
@@ -516,7 +515,7 @@ class Security(object):
 
         identity_loaded.connect_via(app)(_on_identity_loaded)
 
-        self._state = state = _get_state(app, datastore, **self._kwargs)
+        self._state = state = _get_state(app, datastore, **kwargs)
 
         if register_blueprint:
             app.register_blueprint(create_blueprint(state, __name__))

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -461,30 +461,52 @@ class Security(object):
 
     :param app: The application.
     :param datastore: An instance of a user datastore.
+    :param register_blueprint: to register the Security blueprint or not.
+    :param login_form: set form for the login view
+    :param register_form: set form for the register view
+    :param confirm_register_form: set form for the confirm register view
+    :param forgot_password_form: set form for the forgot password view
+    :param reset_password_form: set form for the reset password view
+    :param change_password_form: set form for the change password view
+    :param send_confirmation_form: set form for the send confirmation view
+    :param passwordless_login_form: set form for the passwordless login view
+    :param anonymous_user: class to use for anonymous user
     """
 
-    def __init__(self, app=None, datastore=None, **kwargs):
+    def __init__(self, app=None, datastore=None, register_blueprint=True,
+                 **kwargs):
         self.app = app
-        self.datastore = datastore
+        self._datastore = datastore
+        self._register_blueprint = register_blueprint
+        self._kwargs = dict(login_form=None,
+                            register_form=None,
+                            confirm_register_form=None,
+                            forgot_password_form=None,
+                            reset_password_form=None,
+                            change_password_form=None,
+                            send_confirmation_form=None,
+                            passwordless_login_form=None,
+                            anonymous_user=None)
+        self._kwargs.update(kwargs)
 
+        self._state = None  # set by init_app
         if app is not None and datastore is not None:
-            self._state = self.init_app(app, datastore, **kwargs)
+            self._state = self.init_app(app, datastore, **self._kwargs)
 
-    def init_app(self, app, datastore=None, register_blueprint=True,
-                 login_form=None, confirm_register_form=None,
-                 register_form=None, forgot_password_form=None,
-                 reset_password_form=None, change_password_form=None,
-                 send_confirmation_form=None, passwordless_login_form=None,
-                 anonymous_user=None):
+    def init_app(self, app, datastore=None, register_blueprint=None, **kwargs):
         """Initializes the Flask-Security extension for the specified
-        application and datastore implentation.
+        application and datastore implementation.
 
         :param app: The application.
         :param datastore: An instance of a user datastore.
         :param register_blueprint: to register the Security blueprint or not.
         """
         self.app = app
-        self.datastore = datastore
+        if datastore is None:
+            datastore = self._datastore
+        if register_blueprint is None:
+            register_blueprint = self._register_blueprint
+        self._kwargs.update(kwargs)
 
         for key, value in _default_config.items():
             app.config.setdefault('SECURITY_' + key, value)
@@ -494,16 +516,7 @@ class Security(object):
 
         identity_loaded.connect_via(app)(_on_identity_loaded)
 
-        state = _get_state(app, self.datastore,
-                           login_form=login_form,
-                           confirm_register_form=confirm_register_form,
-                           register_form=register_form,
-                           forgot_password_form=forgot_password_form,
-                           reset_password_form=reset_password_form,
-                           change_password_form=change_password_form,
-                           send_confirmation_form=send_confirmation_form,
-                           passwordless_login_form=passwordless_login_form,
-                           anonymous_user=anonymous_user)
+        self._state = state = _get_state(app, datastore, **self._kwargs)
 
         if register_blueprint:
             app.register_blueprint(create_blueprint(state, __name__))

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -166,3 +166,20 @@ def test_access_datastore_from_factory(app, datastore):
 
     assert security.datastore is not None
     assert security.app is not None
+
+
+def test_access_datastore_from_app_factory_pattern(app, datastore):
+    security = Security(datastore=datastore)
+    security.init_app(app)
+
+    assert security.datastore is not None
+    assert security.app is not None
+
+
+def test_init_app_kwargs_override_constructor_kwargs(app, datastore):
+    security = Security(datastore=datastore, login_form='__init__login_form',
+                        register_form='__init__register_form')
+    security.init_app(app, login_form='init_app_login_form')
+
+    assert security.login_form == 'init_app_login_form'
+    assert security.register_form == '__init__register_form'


### PR DESCRIPTION
Currently, this extension cannot be used with the factory pattern, except by subclassing `Security` to override the `__init__` and `init_app` methods. The problem is two-fold: `kwargs` passed to `__init__` don't get passed on to `init_app`, and secondly, when setting the `datastore` via `__init__`, when `init_app(app)` is later called, it wipes out the `datastore`. This PR replaces #495, which appears to have stalled.

The datastore bug was introduced in #537, and was warned about by @mattupstate in a [comment](https://github.com/mattupstate/flask-security/pull/537#issuecomment-272888626), but that PR got accidentally merged anyway.

The following is currently the only method of initializing the extension:
```python
app = Flask(__name__)
datastore = SQLAlchemyUserDatastore(db, User, Role)
security = Security(app, datastore, **kwargs)
```
It remains supported, and this PR makes it possible to also initialize this way:
```python
# extensions.py
datastore = SQLAlchemyUserDatastore(db, User, Role)
security = Security(datastore=datastore, **kwargs)

# later, in create_app.py
from extensions import security
def create_app():
    app = Flask(__name__)
    security.init_app(app)
    return app
```