### PR TITLE
core._user_loader: Explicitly cast user_id to int

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -218,7 +218,7 @@ _default_forms = {
 
 
 def _user_loader(user_id):
-    return _security.datastore.find_user(id=user_id)
+    return _security.datastore.find_user(id=int(user_id))
 
 
 def _request_loader(request):


### PR DESCRIPTION
[According to the documentation](https://flask-login.readthedocs.io/en/latest/#how-it-works), Flask-Login's `user_loader` callback mechanism passes `user_id` through as a Unicode string. This means, without any type checking, `user_id` will be passed through to the user datastores as a string.

This causes problems, at least when using `SQLAlchemyUserDatastore`, because it makes direct comparisons using `filter_by` to find the ID, which is usually an integer. We're using CockroachDB, and this type conflict causes it to raise exceptions (traceback not from `HEAD`, but bug still exists in it):

```
Traceback (most recent call last):
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/flask/app.py", line 1610, in full_dispatch_request
    rv = self.preprocess_request()
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/flask/app.py", line 1831, in preprocess_request
    rv = func()
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/flask_principal.py", line 477, in _on_before_request
    identity = loader()
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/flask_security/core.py", line 245, in _identity_loader
    if not isinstance(current_user._get_current_object(), AnonymousUserMixin):
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/werkzeug/local.py", line 306, in _get_current_object
    return self.__local()
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/flask_login/utils.py", line 26, in <lambda>
    current_user = LocalProxy(lambda: _get_user())
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/flask_login/utils.py", line 302, in _get_user
    current_app.login_manager._load_user()
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/flask_login/login_manager.py", line 317, in _load_user
    return self.reload_user()
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/flask_login/login_manager.py", line 279, in reload_user
    user = self.user_callback(user_id)
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/flask_security/core.py", line 221, in _user_loader
    return _security.datastore.find_user(id=user_id)
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/flask_security/datastore.py", line 254, in find_user
    return self.user_model.query.filter_by(**kwargs).first()
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/sqlalchemy/orm/query.py", line 2755, in first
    ret = list(self[0:1])
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/sqlalchemy/orm/query.py", line 2547, in __getitem__
    return list(res)
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/sqlalchemy/orm/query.py", line 2855, in __iter__
    return self._execute_and_instances(context)
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/sqlalchemy/orm/query.py", line 2878, in _execute_and_instances
    result = conn.execute(querycontext.statement, self._params)
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/sqlalchemy/engine/base.py", line 945, in execute
    return meth(self, multiparams, params)
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/sqlalchemy/sql/elements.py", line 263, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/sqlalchemy/engine/base.py", line 1053, in _execute_clauseelement
    compiled_sql, distilled_params
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/sqlalchemy/engine/base.py", line 1189, in _execute_context
    context)
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/sqlalchemy/engine/base.py", line 1402, in _handle_dbapi_exception
    exc_info
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/sqlalchemy/util/compat.py", line 203, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb, cause=cause)
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/sqlalchemy/util/compat.py", line 186, in reraise
    raise value.with_traceback(tb)
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/sqlalchemy/engine/base.py", line 1182, in _execute_context
    context)
  File "/opt/catalyst/hotpotato/venv/lib/python3.5/site-packages/sqlalchemy/engine/default.py", line 470, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.InternalError: (psycopg2.InternalError) unsupported comparison operator: <int> = <string>
 [SQL: 'SELECT "user".id AS user_id, "user".email AS user_email, "user".password AS user_password, "user".name AS user_name, "user".active AS user_active, "user".confirmed_at AS user_confirmed_at, "user".last_login_at AS user_last_login_at, "user".current_login_at AS user_current_login_at, "user".last_login_ip AS user_last_login_ip, "user".current_login_ip AS user_current_login_ip, "user".login_count AS user_login_count \nFROM "user" \nWHERE "user".id = %(id_1)s \n LIMIT %(param_1)s'] [parameters: {'id_1': '1', 'param_1': 1}]
```

This PR fixes that by explicitly casting `user_id` to an `int` before it gets passed to `_security.datastore.find_user`. I haven't checked the other user datastore types, but if they were also expecting an integer, this should be fine.