### PR TITLE
Improve German translation

### DIFF
--- a/flask_security/translations/de_DE/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/de_DE/LC_MESSAGES/flask_security.po
@@ -3,15 +3,16 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the Flask-Security
 # project.
-# Ingo Kleiber <ingo@kleiber.me>, 2017.
+# Ingo Kleiber <ingo@kleiber.me>, 2017,
+# Erich Seifert <dev@erichseifert.de>, 2017.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2017-06-06 13:23+0200\n"
-"PO-Revision-Date: 2017-04-30 17:00+0200\n"
-"Last-Translator: Ingo Kleiber <ingo@kleiber.me>\n"
+"PO-Revision-Date: 2017-09-25 09:14+0200\n"
+"Last-Translator: Erich Seifert <dev@erichseifert.de>\n"
 "Language: de_DE\n"
 "Language-Team: de_DE <LL@li.org>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
@@ -22,7 +23,7 @@ msgstr ""
 
 #: flask_security/core.py:99
 msgid "Login Required"
-msgstr "Login erforderlich"
+msgstr "Anmeldung erforderlich"
 
 #: flask_security/core.py:100
 msgid "Welcome"
@@ -30,11 +31,11 @@ msgstr "Willkommen"
 
 #: flask_security/core.py:101
 msgid "Please confirm your email"
-msgstr "Bitte E-Mail Adresse bestätigen"
+msgstr "Bitte E-Mail-Adresse bestätigen"
 
 #: flask_security/core.py:102
 msgid "Login instructions"
-msgstr "Anmeldeinstruktionen"
+msgstr "Anmeldeanleitung"
 
 #: flask_security/core.py:103
 #: flask_security/templates/security/email/reset_notice.html:1
@@ -56,15 +57,15 @@ msgstr "Keine Berechtigung um diese Ressource zu sehen."
 #: flask_security/core.py:134
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
-msgstr "Vielen Dank. Bestätigungsinstruktionen wurden an %(email)s gesendet."
+msgstr "Vielen Dank. Bestätigungsanleitung wurde an %(email)s gesendet."
 
 #: flask_security/core.py:138
 msgid "Thank you. Your email has been confirmed."
-msgstr "Vielen Dank. Die E-Mail Adresse wurde bestätigt."
+msgstr "Vielen Dank. Die E-Mail-Adresse wurde bestätigt."
 
 #: flask_security/core.py:140
 msgid "Your email has already been confirmed."
-msgstr "Die E-Mail Adresse wurde bereits bestätigt."
+msgstr "Die E-Mail-Adresse wurde bereits bestätigt."
 
 #: flask_security/core.py:142
 msgid "Invalid confirmation token."
@@ -91,7 +92,7 @@ msgstr "Weiterleitungen außerhalb der Domain sind verboten"
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr ""
-"Instruktionen um das Passwort wiederherzustellen wurden an %(email)s "
+"Eine Anleitung, um das Passwort wiederherzustellen wurde an %(email)s "
 "gesendet."
 
 #: flask_security/core.py:155
@@ -100,8 +101,8 @@ msgid ""
 "You did not reset your password within %(within)s. New instructions have "
 "been sent to %(email)s."
 msgstr ""
-"Das Passwort wurde nicht innerhalb von %(within)s zurückgesetzt. Neue "
-"Instruktionen wurden an %(email)s gesendet."
+"Das Passwort wurde nicht innerhalb von %(within)s zurückgesetzt. Eine neue "
+"Anleitung wurde an %(email)s gesendet."
 
 #: flask_security/core.py:158
 msgid "Invalid reset password token."
@@ -109,12 +110,12 @@ msgstr "Ungültiger Passwortwiederherstellungscode."
 
 #: flask_security/core.py:160
 msgid "Email requires confirmation."
-msgstr "Die E-Mail Adresse muss bestätigt werden."
+msgstr "Die E-Mail-Adresse muss bestätigt werden."
 
 #: flask_security/core.py:162
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
-msgstr "Bestätigungsinstruktionen wurden an %(email)s gesendet."
+msgstr "Bestätigungsanleitung wurde an %(email)s gesendet."
 
 #: flask_security/core.py:164
 #, python-format
@@ -122,7 +123,7 @@ msgid ""
 "You did not confirm your email within %(within)s. New instructions to "
 "confirm your email have been sent to %(email)s."
 msgstr ""
-"Die E-Mail Adresse wurden nicht innerhalb von %(within)s bestätigt. Neue "
+"Die E-Mail-Adresse wurden nicht innerhalb von %(within)s bestätigt. Neue "
 "Instruktionen wurden an %(email)s gesendet."
 
 #: flask_security/core.py:168
@@ -131,13 +132,13 @@ msgid ""
 "You did not login within %(within)s. New instructions to login have been "
 "sent to %(email)s."
 msgstr ""
-"Die Anmeldung erfolgte nicht in %(within)s. Neue Instruktionen wurden an "
+"Die Anmeldung erfolgte nicht in %(within)s. Eine neue Anleitung wurde an "
 "%(email)s gesendet."
 
 #: flask_security/core.py:171
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
-msgstr "Instruktionen zur Anmeldung wurden an %(email)s gesendet."
+msgstr "Eine Anleitung zur Anmeldung wurde an %(email)s gesendet."
 
 #: flask_security/core.py:173
 msgid "Invalid login token."
@@ -149,11 +150,11 @@ msgstr "Konto ist deaktiviert."
 
 #: flask_security/core.py:177
 msgid "Email not provided"
-msgstr "Keine E-Mail Adresse angegeben"
+msgstr "Keine E-Mail-Adresse angegeben"
 
 #: flask_security/core.py:179
 msgid "Invalid email address"
-msgstr "Ungültige E-Mail Adresse"
+msgstr "Ungültige E-Mail-Adresse"
 
 #: flask_security/core.py:181
 msgid "Password not provided"
@@ -169,7 +170,7 @@ msgstr "Das Passwort muss mindestens 6 Zeichen lang sein"
 
 #: flask_security/core.py:187
 msgid "Specified user does not exist"
-msgstr "Spezifizierter Benutzer existiert nicht"
+msgstr "Angegebener Benutzer existiert nicht"
 
 #: flask_security/core.py:189
 msgid "Invalid password"
@@ -188,8 +189,8 @@ msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr ""
-"Das Passwort wurde erfolgreich wiederhergestellt und der Login erfolgte "
-"automatisch."
+"Das Passwort wurde erfolgreich wiederhergestellt und die Anmeldung "
+"erfolgte automatisch."
 
 #: flask_security/core.py:198
 msgid "Your new password must be different than your previous password."
@@ -201,15 +202,15 @@ msgstr "Das Passwort wurde erfolgreich geändert."
 
 #: flask_security/core.py:203
 msgid "Please log in to access this page."
-msgstr "Bitte Anmelden um diese Seite zu sehen."
+msgstr "Bitte anmelden, um diese Seite zu sehen."
 
 #: flask_security/core.py:205
 msgid "Please reauthenticate to access this page."
-msgstr "Bitte neu authentifizieren um auf diese Seite zuzugreifen."
+msgstr "Bitte neu authentifizieren, um auf diese Seite zuzugreifen."
 
 #: flask_security/forms.py:30
 msgid "Email Address"
-msgstr "E-Mail Adresse"
+msgstr "E-Mail-Adresse"
 
 #: flask_security/forms.py:31
 msgid "Password"
@@ -232,7 +233,7 @@ msgstr "Registrieren"
 
 #: flask_security/forms.py:35
 msgid "Resend Confirmation Instructions"
-msgstr "Bestätigungsinstruktionen neu senden"
+msgstr "Bestätigungsanleitung neu senden"
 
 #: flask_security/forms.py:36
 msgid "Recover Password"
@@ -256,7 +257,7 @@ msgstr "Passwort ändern"
 
 #: flask_security/forms.py:41
 msgid "Send Login Link"
-msgstr "Login-Link versenden"
+msgstr "Anmelde-Link versenden"
 
 #: flask_security/templates/security/_menu.html:2
 msgid "Menu"
@@ -276,7 +277,7 @@ msgstr "Passwort ändern"
 
 #: flask_security/templates/security/forgot_password.html:3
 msgid "Send password reset instructions"
-msgstr "Senden von Instruktionen zur Passwortzurücksetzung"
+msgstr "Anleitung zur Passwortzurücksetzung versenden"
 
 #: flask_security/templates/security/reset_password.html:3
 msgid "Reset password"
@@ -284,7 +285,7 @@ msgstr "Passwort zurücksetzen"
 
 #: flask_security/templates/security/send_confirmation.html:3
 msgid "Resend confirmation instructions"
-msgstr "Bestätigungsinstruktionen erneut versenden"
+msgstr "Bestätigungsanleitung erneut versenden"
 
 #: flask_security/templates/security/email/change_notice.html:1
 msgid "Your password has been changed."
@@ -296,16 +297,16 @@ msgstr "Falls das Passwort nicht geändert wurde"
 
 #: flask_security/templates/security/email/change_notice.html:3
 msgid "click here to reset it"
-msgstr "hier klicken um es zurückzusetzen"
+msgstr "hier klicken, um es zurückzusetzen"
 
 #: flask_security/templates/security/email/confirmation_instructions.html:1
 msgid "Please confirm your email through the link below:"
-msgstr "Bitte die E-Mail Adresse durch den Link unten bestätigen:"
+msgstr "Bitte die E-Mail-Adresse durch den Link unten bestätigen:"
 
 #: flask_security/templates/security/email/confirmation_instructions.html:3
 #: flask_security/templates/security/email/welcome.html:6
 msgid "Confirm my account"
-msgstr "Den Account bestätigen"
+msgstr "Das Konto bestätigen"
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/welcome.html:1
@@ -323,9 +324,9 @@ msgstr "Jetzt anmelden"
 
 #: flask_security/templates/security/email/reset_instructions.html:1
 msgid "Click here to reset your password"
-msgstr "Hier klicken um das Passwort zurückzusetzen"
+msgstr "Hier klicken, um das Passwort zurückzusetzen"
 
 #: flask_security/templates/security/email/welcome.html:4
 msgid "You can confirm your email through the link below:"
-msgstr "Die E-Mail Adresse kann über den Link unten bestätigt werden"
+msgstr "Die E-Mail-Adresse kann über den Link unten bestätigt werden"
 


### PR DESCRIPTION
Translate all occurrences of "instructions" with "Anleitung" instead of "Instruktionen" to sound less technical;
translate "account" with "Konto" consistently;
translate "login" was translated with "anmelden" or "Anmledung" consistently;
Connect "E-Mail-Adresse" with dashes.