### PR TITLE
Make SECURITY_PASSWORD_SINGLE_HASH a list of scheme ignoring double hash

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -21,7 +21,7 @@ Core
 ``SECURITY_URL_PREFIX``                  Specifies the URL prefix for the
                                          Flask-Security blueprint. Defaults to
                                          ``None``.
-``SECURITY_SUBDOMAIN``                   Specifies the subdomain for the 
+``SECURITY_SUBDOMAIN``                   Specifies the subdomain for the
                                          Flask-Security blueprint. Defaults to
                                          ``None``.
 ``SECURITY_FLASH_MESSAGES``              Specifies whether or not to flash
@@ -46,6 +46,11 @@ Core
                                          ``SECURITY_PASSWORD_SALT``, and then
                                          with a random salt. May be useful for
                                          integrating with other applications.
+                                         It can also be a set of scheme that
+                                         should not be hashed twice.
+                                         Default to a list of known schemes
+                                         not working with double hashing
+                                         (`django_{digest}`, `plaintext`).
                                          Defaults to ``False``.
 ``SECURITY_HASHING_SCHEMES``             List of algorithms used for
                                          creating and validating tokens.

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -48,7 +48,17 @@ _default_config = {
     'I18N_DOMAIN': 'flask_security',
     'PASSWORD_HASH': 'bcrypt',
     'PASSWORD_SALT': None,
-    'PASSWORD_SINGLE_HASH': False,
+    'PASSWORD_SINGLE_HASH': set([
+        'django_argon2',
+        'django_bcrypt_sha256',
+        'django_pbkdf2_sha256',
+        'django_pbkdf2_sha1',
+        'django_bcrypt',
+        'django_salted_md5',
+        'django_salted_sha1',
+        'django_des_crypt',
+        'plaintext'
+    ]),
     'LOGIN_URL': '/login',
     'LOGOUT_URL': '/logout',
     'REGISTER_URL': '/register',

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -48,7 +48,7 @@ _default_config = {
     'I18N_DOMAIN': 'flask_security',
     'PASSWORD_HASH': 'bcrypt',
     'PASSWORD_SALT': None,
-    'PASSWORD_SINGLE_HASH': set([
+    'PASSWORD_SINGLE_HASH': {
         'django_argon2',
         'django_bcrypt_sha256',
         'django_pbkdf2_sha256',
@@ -57,8 +57,8 @@ _default_config = {
         'django_salted_md5',
         'django_salted_sha1',
         'django_des_crypt',
-        'plaintext'
-    ]),
+        'plaintext',
+    },
     'LOGIN_URL': '/login',
     'LOGOUT_URL': '/logout',
     'REGISTER_URL': '/register',

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -450,17 +450,16 @@ def get_identity_attributes(app=None):
 
 def use_double_hash(password_hash=None):
     """Return a bool indicating whether a password should be hashed twice."""
-    single_hash = config_value('PASSWORD_SINGLE_HASH')
-    if single_hash and _security.password_salt:
-        raise RuntimeError('You may not specify a salt with '
-                           'SECURITY_PASSWORD_SINGLE_HASH')
+    # Default to plaintext for backward compatibility with
+    # SECURITY_PASSWORD_SINGLE_HASH = False
+    single_hash = config_value('PASSWORD_SINGLE_HASH') or {'plaintext'}
 
     if password_hash is None:
-        is_plaintext = _security.password_hash == 'plaintext'
+        scheme = _security.password_hash
     else:
-        is_plaintext = _pwd_context.identify(password_hash) == 'plaintext'
+        scheme = _pwd_context.identify(password_hash)
 
-    return not (is_plaintext or single_hash)
+    return not (single_hash is True or scheme in single_hash)
 
 
 @contextmanager

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -8,8 +8,9 @@
 
 from pytest import raises
 from utils import authenticate, init_app_with_options
+from passlib.hash import pbkdf2_sha256, django_pbkdf2_sha256, plaintext
 
-from flask_security.utils import encrypt_password, verify_password
+from flask_security.utils import encrypt_password, verify_password, get_hmac
 
 
 def test_verify_password_bcrypt_double_hash(app, sqlalchemy_datastore):
@@ -30,6 +31,37 @@ def test_verify_password_bcrypt_single_hash(app, sqlalchemy_datastore):
     })
     with app.app_context():
         assert verify_password('pass', encrypt_password('pass'))
+
+
+def test_verify_password_single_hash_list(app, sqlalchemy_datastore):
+    init_app_with_options(app, sqlalchemy_datastore, **{
+        'SECURITY_PASSWORD_HASH': 'bcrypt',
+        'SECURITY_PASSWORD_SALT': 'salty',
+        'SECURITY_PASSWORD_SINGLE_HASH': ['django_pbkdf2_sha256', 'plaintext'],
+        'SECURITY_PASSWORD_SCHEMES': [
+            'bcrypt', 'pbkdf2_sha256', 'django_pbkdf2_sha256', 'plaintext'
+        ]
+    })
+    with app.app_context():
+        # double hash
+        assert verify_password('pass', encrypt_password('pass'))
+        assert verify_password('pass', pbkdf2_sha256.hash(get_hmac('pass')))
+        # single hash
+        assert verify_password('pass', django_pbkdf2_sha256.hash('pass'))
+        assert verify_password('pass', plaintext.hash('pass'))
+
+
+def test_verify_password_backward_compatibility(app, sqlalchemy_datastore):
+    init_app_with_options(app, sqlalchemy_datastore, **{
+        'SECURITY_PASSWORD_HASH': 'bcrypt',
+        'SECURITY_PASSWORD_SINGLE_HASH': False,
+        'SECURITY_PASSWORD_SCHEMES': ['bcrypt', 'plaintext']
+    })
+    with app.app_context():
+        # double hash
+        assert verify_password('pass', encrypt_password('pass'))
+        # single hash
+        assert verify_password('pass', plaintext.hash('pass'))
 
 
 def test_verify_password_bcrypt_rounds_too_low(app, sqlalchemy_datastore):
@@ -58,13 +90,4 @@ def test_missing_hash_salt_option(app, sqlalchemy_datastore):
             'SECURITY_PASSWORD_HASH': 'bcrypt',
             'SECURITY_PASSWORD_SALT': None,
             'SECURITY_PASSWORD_SINGLE_HASH': False,
-        })
-
-
-def test_single_hash_should_have_no_salt(app, sqlalchemy_datastore):
-    with raises(RuntimeError):
-        init_app_with_options(app, sqlalchemy_datastore, **{
-            'SECURITY_PASSWORD_HASH': 'bcrypt',
-            'SECURITY_PASSWORD_SALT': 'salty',
-            'SECURITY_PASSWORD_SINGLE_HASH': True,
         })


### PR DESCRIPTION
This PR makes `SECURITY_PASSWORD_SINGLE_HASH` a list of password hashing schemes that shouldn't be hashed twice allowing easier handling of legacy schemes or imported schemes.

## Use cases
- I want to import my Django passwords in my Flask-Security based app and have `bcrypt` with double hashing as default scheme, but Django only perform single hashing. (handled in default configuration)
- I add Flask-Security to default on `pbkdf2_sha256` hashed once but I want to migrate to `bcrypt` hashed twice without loosing already stored passewords. This can be handled with:
```python
'SECURITY_PASSWORD_HASH': 'bcrypt',
'SECURITY_PASSWORD_SALT': 'any string',
'SECURITY_PASSWORD_SINGLE_HASH': ['pbkdf2_sha256'],
'SECURITY_PASSWORD_SCHEMES': ['bcrypt', 'pbkdf2_sha256']
```

## Backward compatibility
This ensure backward compatibility with the actual behavior: `SECURITY_PASSWORD_SINGLE_HASH = True` disable double hashing and `SECURITY_PASSWORD_SINGLE_HASH = False` ignore double hashing for `plaintext`.

## Default
The default `SECURITY_PASSWORD_SINGLE_HASH` is a list of known scheme not working with double hashing (`django_*` schemes and `plaintext`)

## Side effect
This PR also remove the need to raise an exception if `SECURITY_PASSWORD_SALT` with `SECURITY_PASSWORD_SINGLE_HASH` is defined: having it defined does not break the security, it is simply ignored when not necessary.