### PR TITLE
Adds support for 'token' in email templates

### DIFF
--- a/flask_security/confirmable.py
+++ b/flask_security/confirmable.py
@@ -41,7 +41,8 @@ def send_confirmation_instructions(user):
 
     _security.send_mail(config_value('EMAIL_SUBJECT_CONFIRM'), user.email,
                         'confirmation_instructions', user=user,
-                        confirmation_link=confirmation_link)
+                        confirmation_link=confirmation_link,
+                        token=token)
 
     confirm_instructions_sent.send(app._get_current_object(), user=user,
                                    token=token)

--- a/flask_security/recoverable.py
+++ b/flask_security/recoverable.py
@@ -35,7 +35,8 @@ def send_reset_password_instructions(user):
     if config_value('SEND_PASSWORD_RESET_EMAIL'):
         _security.send_mail(config_value('EMAIL_SUBJECT_PASSWORD_RESET'),
                             user.email, 'reset_instructions',
-                            user=user, reset_link=reset_link)
+                            user=user, reset_link=reset_link,
+                            token=token)
 
     reset_password_instructions_sent.send(
         app._get_current_object(), user=user, token=token

--- a/flask_security/registerable.py
+++ b/flask_security/registerable.py
@@ -38,6 +38,7 @@ def register_user(**kwargs):
     if config_value('SEND_REGISTER_EMAIL'):
         _security.send_mail(config_value('EMAIL_SUBJECT_REGISTER'), user.email,
                             'welcome', user=user,
-                            confirmation_link=confirmation_link)
+                            confirmation_link=confirmation_link,
+                            token=token)
 
     return user

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,7 +150,7 @@ def mongoengine_datastore(app):
     db_name = 'flask_security_test_%s' % str(time.time()).replace('.', '_')
     app.config['MONGODB_SETTINGS'] = {
         'db': db_name,
-        'host': 'localhost',
+        'host': 'mongomock://localhost',
         'port': 27017,
         'alias': db_name
     }

--- a/tests/templates/security/email/welcome.html
+++ b/tests/templates/security/email/welcome.html
@@ -1,0 +1,3 @@
+CUSTOM SEND WELCOME
+{{ global }}
+Token: {{ token }}

--- a/tests/templates/security/email/welcome.txt
+++ b/tests/templates/security/email/welcome.txt
@@ -1,0 +1,3 @@
+templates/security/email/welcome.html CUSTOM SEND WELCOME
+{{ global }}
+Token: {{ token }}

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -10,7 +10,7 @@ from pytest import raises
 from utils import authenticate, init_app_with_options
 from passlib.hash import pbkdf2_sha256, django_pbkdf2_sha256, plaintext
 
-from flask_security.utils import encrypt_password, verify_password, get_hmac
+from flask_security.utils import hash_password, verify_password, get_hmac
 
 
 def test_verify_password_bcrypt_double_hash(app, sqlalchemy_datastore):
@@ -20,7 +20,7 @@ def test_verify_password_bcrypt_double_hash(app, sqlalchemy_datastore):
         'SECURITY_PASSWORD_SINGLE_HASH': False,
     })
     with app.app_context():
-        assert verify_password('pass', encrypt_password('pass'))
+        assert verify_password('pass', hash_password('pass'))
 
 
 def test_verify_password_bcrypt_single_hash(app, sqlalchemy_datastore):
@@ -30,7 +30,7 @@ def test_verify_password_bcrypt_single_hash(app, sqlalchemy_datastore):
         'SECURITY_PASSWORD_SINGLE_HASH': True,
     })
     with app.app_context():
-        assert verify_password('pass', encrypt_password('pass'))
+        assert verify_password('pass', hash_password('pass'))
 
 
 def test_verify_password_single_hash_list(app, sqlalchemy_datastore):
@@ -44,7 +44,7 @@ def test_verify_password_single_hash_list(app, sqlalchemy_datastore):
     })
     with app.app_context():
         # double hash
-        assert verify_password('pass', encrypt_password('pass'))
+        assert verify_password('pass', hash_password('pass'))
         assert verify_password('pass', pbkdf2_sha256.hash(get_hmac('pass')))
         # single hash
         assert verify_password('pass', django_pbkdf2_sha256.hash('pass'))
@@ -59,7 +59,7 @@ def test_verify_password_backward_compatibility(app, sqlalchemy_datastore):
     })
     with app.app_context():
         # double hash
-        assert verify_password('pass', encrypt_password('pass'))
+        assert verify_password('pass', hash_password('pass'))
         # single hash
         assert verify_password('pass', plaintext.hash('pass'))
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,7 +10,7 @@ from flask import Response as BaseResponse
 from flask import json
 
 from flask_security import Security
-from flask_security.utils import encrypt_password
+from flask_security.utils import hash_password
 
 _missing = object
 
@@ -60,7 +60,7 @@ def create_users(ds, count=None):
     for u in users[:count]:
         pw = u[2]
         if pw is not None:
-            pw = encrypt_password(pw)
+            pw = hash_password(pw)
         roles = [ds.find_or_create_role(rn) for rn in u[3]]
         ds.commit()
         user = ds.create_user(


### PR DESCRIPTION
Simple add of the token to be available in the email templates.

When using with an application via REST, being able to integrate with the device native app, using something like Branch.io.  This will allow a click via email to open either the native app, app store, or web site, to perform the function using the token from the request.