### PR TITLE
i18n: configurable the dirname domain

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -30,6 +30,10 @@ Core
 ``SECURITY_I18N_DOMAIN``                 Specifies the name for domain
                                          used for translations.
                                          Defaults to ``flask_security``.
+``SECURITY_I18N_DOMAIN``                 Specifies the directory containing the
+                                         ``MO`` files used for translations.
+                                         Defaults to
+                                         ``[PATH_LIB]/flask_security/translations``.
 ``SECURITY_PASSWORD_HASH``               Specifies the password hash algorithm to
                                          use when hashing passwords. Recommended
                                          values for production systems are

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -30,7 +30,7 @@ Core
 ``SECURITY_I18N_DOMAIN``                 Specifies the name for domain
                                          used for translations.
                                          Defaults to ``flask_security``.
-``SECURITY_I18N_DOMAIN``                 Specifies the directory containing the
+``SECURITY_I18N_DIRNAME``                Specifies the directory containing the
                                          ``MO`` files used for translations.
                                          Defaults to
                                          ``[PATH_LIB]/flask_security/translations``.

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -46,8 +46,8 @@ _default_config = {
     'SUBDOMAIN': None,
     'FLASH_MESSAGES': True,
     'I18N_DOMAIN': 'flask_security',
-    'I18N_DIRNAME': pkg_resources.resource_filename('flask_security', \
-        'translations'),
+    'I18N_DIRNAME': pkg_resources.resource_filename(
+        'flask_security', 'translations'),
     'PASSWORD_HASH': 'bcrypt',
     'PASSWORD_SALT': None,
     'PASSWORD_SINGLE_HASH': {

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -46,6 +46,8 @@ _default_config = {
     'SUBDOMAIN': None,
     'FLASH_MESSAGES': True,
     'I18N_DOMAIN': 'flask_security',
+    'I18N_DIRNAME': pkg_resources.resource_filename('flask_security', \
+        'translations'),
     'PASSWORD_HASH': 'bcrypt',
     'PASSWORD_SALT': None,
     'PASSWORD_SINGLE_HASH': {
@@ -311,7 +313,7 @@ def _get_pwd_context(app):
 
 def _get_i18n_domain(app):
     return Domain(
-        pkg_resources.resource_filename('flask_security', 'translations'),
+        dirname=cv('I18N_DIRNAME', app=app),
         domain=cv('I18N_DOMAIN', app=app)
     )
 


### PR DESCRIPTION
We can't customize translations into our project.
Added the configuration that specifies the directory containing the "MO" files used for translations.