### PR TITLE
Added config option 'SECURITY_USER_ACTIVE_BY_DEFAULT'

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -82,6 +82,9 @@ Core
 ``SECURITY_DEFAULT_HTTP_AUTH_REALM``     Specifies the default authentication
                                          realm when using basic HTTP auth.
                                          Defaults to ``Login Required``
+``MANUAL_USER_ACTIVATION``               Specifies whether new users must be
+                                         manually activated by an administrator.
+                                         Defaults to ``False``.
 ======================================== =======================================
 
 

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -136,6 +136,7 @@ _default_config = {
     ],
     'DEPRECATED_HASHING_SCHEMES': ['hex_md5'],
     'DATETIME_FACTORY': datetime.utcnow,
+    'USER_ACTIVE_BY_DEFAULT': True,
 }
 
 #: Default Flask-Security messages

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -136,7 +136,7 @@ _default_config = {
     ],
     'DEPRECATED_HASHING_SCHEMES': ['hex_md5'],
     'DATETIME_FACTORY': datetime.utcnow,
-    'USER_ACTIVE_BY_DEFAULT': True,
+    'MANUAL_USER_ACTIVATION': False,
 }
 
 #: Default Flask-Security messages

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -124,7 +124,7 @@ class UserDatastore(object):
         return user, role
 
     def _prepare_create_user_args(self, **kwargs):
-        kwargs.setdefault('active', config_value('USER_ACTIVE_BY_DEFAULT'))
+        kwargs.setdefault('active', not config_value('MANUAL_USER_ACTIVATION'))
         roles = kwargs.get('roles', [])
         for i, role in enumerate(roles):
             rn = role.name if isinstance(role, self.role_model) else role

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -9,7 +9,7 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from .utils import get_identity_attributes, string_types
+from .utils import get_identity_attributes, string_types, config_value
 
 
 class Datastore(object):
@@ -124,7 +124,7 @@ class UserDatastore(object):
         return user, role
 
     def _prepare_create_user_args(self, **kwargs):
-        kwargs.setdefault('active', True)
+        kwargs.setdefault('active', config_value('USER_ACTIVE_BY_DEFAULT'))
         roles = kwargs.get('roles', [])
         for i, role in enumerate(roles):
             rn = role.name if isinstance(role, self.role_model) else role


### PR DESCRIPTION
You can use it to specify whether or not users should be active by default, useful if you want registered users to be reviewed and activated manually.

Let's say you have a small company website and you want your employees to register with their email and passwords but you want to be able to activate them manually so that you can control who gets accepted, you could do it by setting `SECURITY_USER_ACTIVE_BY_DEFAULT` to `False` like this:

```
app.config['SECURITY_USER_ACTIVE_BY_DEFAULT'] = False
```

You could easily review and accept (or reject) registration attempts with a tool like Flask-Admin 