### PR TITLE
Let User model specify password verification and update methods

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -16,8 +16,9 @@ from datetime import datetime
 import pkg_resources
 from flask import current_app, render_template
 from flask_babelex import Domain
+from flask_login import AnonymousUserMixin, LoginManager
 from flask_login import UserMixin as BaseUserMixin
-from flask_login import AnonymousUserMixin, LoginManager, current_user
+from flask_login import current_user
 from flask_principal import Identity, Principal, RoleNeed, UserNeed, \
     identity_loaded
 from itsdangerous import URLSafeTimedSerializer
@@ -28,9 +29,10 @@ from werkzeug.local import LocalProxy
 from .forms import ChangePasswordForm, ConfirmRegisterForm, \
     ForgotPasswordForm, LoginForm, PasswordlessLoginForm, RegisterForm, \
     ResetPasswordForm, SendConfirmationForm
+from .utils import _
 from .utils import config_value as cv
-from .utils import _, get_config, hash_data, localize_callback, string_types, \
-    url_for_security, verify_hash, send_mail, verify_and_update_password
+from .utils import get_config, hash_data, localize_callback, send_mail, \
+    string_types, url_for_security, verify_and_update_password, verify_hash
 from .views import create_blueprint
 
 # Convenient references

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -30,7 +30,7 @@ from .forms import ChangePasswordForm, ConfirmRegisterForm, \
     ResetPasswordForm, SendConfirmationForm
 from .utils import config_value as cv
 from .utils import _, get_config, hash_data, localize_callback, string_types, \
-    url_for_security, verify_hash, send_mail
+    url_for_security, verify_hash, send_mail, verify_and_update_password
 from .views import create_blueprint
 
 # Convenient references
@@ -406,6 +406,10 @@ class UserMixin(BaseUserMixin):
     def get_security_payload(self):
         """Serialize user object as response payload."""
         return {'id': str(self.id)}
+
+    def verify_and_update_password(self, password):
+        """Verify and update user password using configured hash."""
+        return verify_and_update_password(password, self)
 
 
 class AnonymousUser(AnonymousUserMixin):

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -80,7 +80,7 @@ def _check_http_auth():
         return False
     user = _security.datastore.get_user(auth.username)
 
-    if user and utils.verify_and_update_password(auth.password, user):
+    if user and user.verify_and_update_password(auth.password):
         _security.datastore.commit()
         app = current_app._get_current_object()
         _request_ctx_stack.top.user = user

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -21,8 +21,7 @@ from wtforms import BooleanField, Field, HiddenField, PasswordField, \
 
 from .confirmable import requires_confirmation
 from .utils import _, _datastore, config_value, get_message, hash_password, \
-    localize_callback, url_for_security, validate_redirect_url, \
-    verify_and_update_password
+    localize_callback, url_for_security, validate_redirect_url
 
 lazy_gettext = make_lazy_gettext(lambda: localize_callback)
 
@@ -242,7 +241,7 @@ class LoginForm(Form, NextFormMixin):
             # Reduce timing variation between existing and non-existung users
             hash_password(self.password.data)
             return False
-        if not verify_and_update_password(self.password.data, self.user):
+        if not self.user.verify_and_update_password(self.password.data):
             self.password.errors.append(get_message('INVALID_PASSWORD')[0])
             return False
         if requires_confirmation(self.user):
@@ -292,7 +291,7 @@ class ChangePasswordForm(Form, PasswordFormMixin):
         if not super(ChangePasswordForm, self).validate():
             return False
 
-        if not verify_and_update_password(self.password.data, current_user):
+        if not current_user.verify_and_update_password(self.password.data):
             self.password.errors.append(get_message('INVALID_PASSWORD')[0])
             return False
         if self.password.data == self.new_password.data:


### PR DESCRIPTION
Added the `verify_and_update_password` functionality to the `UserMixin` class, and use this method for `validate` in `LoginForm`. This enables the end user to overload and use custom verification methods, e.g. LDAP or AD server.