### PR TITLE
Fix documentation for #781

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -40,10 +40,8 @@ Core
                                          ``bcrypt``, ``sha512_crypt``, or
                                          ``pbkdf2_sha512``. Defaults to
                                          ``bcrypt``.
-``SECURITY_PASSWORD_SALT``               Specifies the HMAC salt. This is only
-                                         used if the password hash type is set
-                                         to something other than plain text.
-                                         Defaults to ``None``.
+``SECURITY_PASSWORD_SALT``               Specifies the HMAC salt. Defaults to
+                                         ``None``.
 ``SECURITY_PASSWORD_SINGLE_HASH``        Specifies that passwords should only be
                                          hashed once. By default, passwords are
                                          hashed twice, first with

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -40,6 +40,8 @@ possible using SQLAlchemy:
     app.config['DEBUG'] = True
     app.config['SECRET_KEY'] = 'super-secret'
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    # Bcrypt is set as default SECURITY_PASSWORD_HASH, which requires a salt
+    app.config['SECURITY_PASSWORD_SALT'] = 'super-secret-random-salt'
 
     # Create database connection object
     db = SQLAlchemy(app)
@@ -233,6 +235,8 @@ possible using MongoEngine:
     app = Flask(__name__)
     app.config['DEBUG'] = True
     app.config['SECRET_KEY'] = 'super-secret'
+    # Bcrypt is set as default SECURITY_PASSWORD_HASH, which requires a salt
+    app.config['SECURITY_PASSWORD_SALT'] = 'super-secret-random-salt'
 
     # MongoDB Config
     app.config['MONGODB_DB'] = 'mydatabase'
@@ -307,6 +311,8 @@ possible using Peewee:
         'name': 'example.db',
         'engine': 'peewee.SqliteDatabase',
     }
+    # Bcrypt is set as default SECURITY_PASSWORD_HASH, which requires a salt
+    app.config['SECURITY_PASSWORD_SALT'] = 'super-secret-random-salt'
 
     # Create database connection object
     db = Database(app)


### PR DESCRIPTION
This fixes the documentation. But, on the same topic, currently the extension doesn't really support plaintext anymore, and I guess it's not encouraged per se:

https://github.com/mattupstate/flask-security/blob/89198288bc416a7921b4973d8e897993942bb428/flask_security/utils.py#L120-L127

So why not eliminate it completely? Additionally, the transparent update of plaintext passwords to the configured hash is also something arguable (backward compatibility?)