### PR TITLE
Add option SECURITY_LOGIN_SHOW_USER_EXISTENCE to hide 'user does not …

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -295,6 +295,12 @@ Miscellaneous
                                               the value of
                                               ``SECURITY_CONFIRMABLE`` is set to
                                               ``True``. Defaults to ``False``.
+``SECURITY_LOGIN_SHOW_USER_EXISTENCE``        Specifies the login api whether to
+                                              show user does not exist message
+                                              ``SECURITY_MSG_USER_DOES_NOT_EXIST``
+                                              or empty password message
+                                              ``SECURITY_MSG_PASSWORD_NOT_SET``.
+                                              Defaults to ``True``.
 ``SECURITY_CONFIRM_SALT``                     Specifies the salt value when
                                               generating confirmation
                                               links/tokens. Defaults to

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -98,6 +98,7 @@ _default_config = {
     'CONFIRM_EMAIL_WITHIN': '5 days',
     'RESET_PASSWORD_WITHIN': '5 days',
     'LOGIN_WITHOUT_CONFIRMATION': False,
+    'LOGIN_SHOW_USER_EXISTENCE': True,
     'EMAIL_SENDER': LocalProxy(lambda: current_app.config.get(
         'MAIL_DEFAULT_SENDER', 'no-reply@localhost'
     )),

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -232,14 +232,22 @@ class LoginForm(Form, NextFormMixin):
         self.user = _datastore.get_user(self.email.data)
 
         if self.user is None:
-            self.email.errors.append(get_message('USER_DOES_NOT_EXIST')[0])
-            # Reduce timing variation between existing and non-existung users
-            hash_password(self.password.data)
+            if current_app.extensions['security'].login_show_user_existence:
+                self.email.errors.append(get_message('USER_DOES_NOT_EXIST')[0])
+            else:
+                self.password.errors.append(get_message('INVALID_PASSWORD')[0])
+                # Reduce timing variation between existing and non-existung
+                # users
+                hash_password(self.password.data)
             return False
         if not self.user.password:
-            self.password.errors.append(get_message('PASSWORD_NOT_SET')[0])
-            # Reduce timing variation between existing and non-existung users
-            hash_password(self.password.data)
+            if current_app.extensions['security'].login_show_user_existence:
+                self.password.errors.append(get_message('PASSWORD_NOT_SET')[0])
+            else:
+                self.password.errors.append(get_message('INVALID_PASSWORD')[0])
+                # Reduce timing variation between existing and non-existung
+                # users
+                hash_password(self.password.data)
             return False
         if not self.user.verify_and_update_password(self.password.data):
             self.password.errors.append(get_message('INVALID_PASSWORD')[0])


### PR DESCRIPTION
Add option SECURITY_LOGIN_SHOW_USER_EXISTENCE to hide 'user does not exist' in /login error message, fix #673