### PR TITLE
Clarify that a commit is needed after login_user

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -201,9 +201,10 @@ Feature Flags
                           option. Defaults to ``False``.
 ``SECURITY_TRACKABLE``    Specifies if Flask-Security should track basic user
                           login statistics. If set to ``True``, ensure your
-                          models have the required fields/attributes. Be sure to
-                          use `ProxyFix <http://flask.pocoo.org/docs/0.10/deploying/wsgi-standalone/#proxy-setups>`_ if you are using a proxy. Defaults to
-                          ``False``
+                          models have the required fields/attributes
+                          and make sure to commit changes after calling 
+                          ``login_user``. Be sure to use `ProxyFix <http://flask.pocoo.org/docs/0.10/deploying/wsgi-standalone/#proxy-setups>`_ if you are using a proxy. 
+                          Defaults to ``False``
 ``SECURITY_PASSWORDLESS`` Specifies if Flask-Security should enable the
                           passwordless login feature. If set to ``True``, users
                           are not required to enter a password to login but are


### PR DESCRIPTION
Previously one needed to look at the API documentation for `login_user` to know that a commit was necessary to get tracking to work. This adds a small note to the entry for `SECURITY_TRACKABLE` indicating that a commit is needed.