### PR TITLE
Mail token template support

### DIFF
--- a/flask_security/confirmable.py
+++ b/flask_security/confirmable.py
@@ -41,7 +41,8 @@ def send_confirmation_instructions(user):
 
     _security.send_mail(config_value('EMAIL_SUBJECT_CONFIRM'), user.email,
                         'confirmation_instructions', user=user,
-                        confirmation_link=confirmation_link)
+                        confirmation_link=confirmation_link,
+                        token=token)
 
     confirm_instructions_sent.send(app._get_current_object(), user=user,
                                    token=token)

--- a/flask_security/recoverable.py
+++ b/flask_security/recoverable.py
@@ -35,7 +35,8 @@ def send_reset_password_instructions(user):
     if config_value('SEND_PASSWORD_RESET_EMAIL'):
         _security.send_mail(config_value('EMAIL_SUBJECT_PASSWORD_RESET'),
                             user.email, 'reset_instructions',
-                            user=user, reset_link=reset_link)
+                            user=user, reset_link=reset_link,
+                            token=token)
 
     reset_password_instructions_sent.send(
         app._get_current_object(), user=user, token=token

--- a/flask_security/registerable.py
+++ b/flask_security/registerable.py
@@ -38,6 +38,7 @@ def register_user(**kwargs):
     if config_value('SEND_REGISTER_EMAIL'):
         _security.send_mail(config_value('EMAIL_SUBJECT_REGISTER'), user.email,
                             'welcome', user=user,
-                            confirmation_link=confirmation_link)
+                            confirmation_link=confirmation_link,
+                            token=token)
 
     return user

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ tests_require = [
     'pytest-translations>=1.0.4',
     'pytest>=3.0.5',
     'sqlalchemy>=0.8.0',
+    'mongomock>=3.13.0',
 ]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,9 @@ tests_require = [
     'pytest-flakes>=1.0.1',
     'pytest-pep8>=1.0.6',
     'pytest-translations>=1.0.4',
-    'pymongo==3.7.2',
     'pytest>=3.0.5',
     'sqlalchemy>=0.8.0',
+    'pymongo==3.7.2',
     'mongomock>=3.13.0',
     'pytest-mongo==1.2.1'
 ]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ readme = open('README.rst').read()
 
 tests_require = [
     'Flask-CLI>=0.4.0',
-    'Flask-Mongoengine>=0.9.0',
+    'Flask-Mongoengine>=0.9.5',
     'Flask-Peewee>=0.6.5',
     'Flask-SQLAlchemy>=1.0',
     'bcrypt>=1.0.2',
@@ -24,10 +24,13 @@ tests_require = [
     'pytest-flakes>=1.0.1',
     'pytest-pep8>=1.0.6',
     'pytest-translations>=1.0.4',
+    'pymongo==3.7.2',
     'pytest>=3.0.5',
     'sqlalchemy>=0.8.0',
     'mongomock>=3.13.0',
+    'pytest-mongo==1.2.1'
 ]
+
 
 extras_require = {
     'docs': [

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ readme = open('README.rst').read()
 
 tests_require = [
     'Flask-CLI>=0.4.0',
-    'Flask-Mongoengine>=0.7.0',
+    'Flask-Mongoengine>=0.9.0',
     'Flask-Peewee>=0.6.5',
     'Flask-SQLAlchemy>=1.0',
     'bcrypt>=1.0.2',
@@ -16,7 +16,7 @@ tests_require = [
     'coverage>=4.0',
     'isort>=4.2.2',
     'mock>=1.3.0',
-    'mongoengine>=0.10.0',
+    'mongoengine>=0.16.0',
     'pony>=0.7.1',
     'pydocstyle>=1.0.0',
     'pytest-cache>=1.0',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,7 +150,7 @@ def mongoengine_datastore(app):
     db_name = 'flask_security_test_%s' % str(time.time()).replace('.', '_')
     app.config['MONGODB_SETTINGS'] = {
         'db': db_name,
-        'host': 'localhost',
+        'host': 'mongomock://localhost',
         'port': 27017,
         'alias': db_name
     }

--- a/tests/templates/security/email/welcome.html
+++ b/tests/templates/security/email/welcome.html
@@ -1,0 +1,3 @@
+CUSTOM SEND WELCOME
+{{ global }}
+Token: {{ token }}

--- a/tests/templates/security/email/welcome.txt
+++ b/tests/templates/security/email/welcome.txt
@@ -1,0 +1,3 @@
+templates/security/email/welcome.html CUSTOM SEND WELCOME
+{{ global }}
+Token: {{ token }}

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -41,10 +41,9 @@ def test_confirmable_flag(app, client, sqlalchemy_datastore, get_message):
     # Test login before confirmation
     email = 'dude@lp.com'
 
-    with app.mail.record_messages() as outbox:
-        with capture_registrations() as registrations:
-            data = dict(email=email, password='password', next='')
-            response = client.post('/register', data=data)
+    with capture_registrations() as registrations:
+        data = dict(email=email, password='password', next='')
+        response = client.post('/register', data=data)
 
     assert response.status_code == 302
 

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -261,4 +261,3 @@ def test_optional_token_in_welcome_email(app, client):
     # Test email contains Token information
     with app.test_request_context():
         assert registrations[0]['confirm_token'] in outbox[0].as_string()
-

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -252,8 +252,8 @@ def test_optional_token_in_welcome_email(app, client):
     with capture_registrations() as registrations:
         with app.mail.record_messages() as outbox:
             data = dict(email='token@lp.com', password='password', next='')
-            response = client.post('/register', 
-                                   data=data, 
+            response = client.post('/register',
+                                   data=data,
                                    follow_redirects=True)
 
     assert response.status_code == 200

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -254,4 +254,4 @@ def test_optional_token_in_welcome_email(app, client):
 
     # Test email contains Token information
     with app.test_request_context():
-        assert registrations[0]['confirm_token'] in str(outbox[0].as_string())
+        assert registrations[0]['confirm_token'] in outbox[0].body

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -7,7 +7,6 @@
 """
 
 import time
-import os
 
 import pytest
 from flask import Flask
@@ -254,9 +253,6 @@ def test_optional_token_in_welcome_email(app, client):
         with app.mail.record_messages() as outbox:
             data = dict(email='token@lp.com', password='password', next='')
             response = client.post('/register', data=data, follow_redirects=True)
-
-            user = registrations[0]['user']
-            token = registrations[0]['confirm_token']
 
     assert response.status_code == 200
 

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -252,7 +252,9 @@ def test_optional_token_in_welcome_email(app, client):
     with capture_registrations() as registrations:
         with app.mail.record_messages() as outbox:
             data = dict(email='token@lp.com', password='password', next='')
-            response = client.post('/register', data=data, follow_redirects=True)
+            response = client.post('/register', 
+                                   data=data, 
+                                   follow_redirects=True)
 
     assert response.status_code == 200
 

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -48,11 +48,6 @@ def test_confirmable_flag(app, client, sqlalchemy_datastore, get_message):
 
     assert response.status_code == 302
 
-    # Test email contains Token information
-    with app.test_request_context():
-        print("Message: {}".format(outbox[0].as_string()))
-        assert registrations[0]['confirm_token'] in outbox[0].as_string()
-
     response = authenticate(client, email=email)
     assert get_message('CONFIRMATION_REQUIRED') in response.data
 

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -254,4 +254,4 @@ def test_optional_token_in_welcome_email(app, client):
 
     # Test email contains Token information
     with app.test_request_context():
-        assert registrations[0]['confirm_token'] in outbox[0].as_string()
+        assert registrations[0]['confirm_token'] in str(outbox[0].as_string())

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -10,7 +10,7 @@ from pytest import raises
 from utils import authenticate, init_app_with_options
 from passlib.hash import pbkdf2_sha256, django_pbkdf2_sha256, plaintext
 
-from flask_security.utils import encrypt_password, verify_password, get_hmac
+from flask_security.utils import hash_password, verify_password, get_hmac
 
 
 def test_verify_password_bcrypt_double_hash(app, sqlalchemy_datastore):
@@ -20,7 +20,7 @@ def test_verify_password_bcrypt_double_hash(app, sqlalchemy_datastore):
         'SECURITY_PASSWORD_SINGLE_HASH': False,
     })
     with app.app_context():
-        assert verify_password('pass', encrypt_password('pass'))
+        assert verify_password('pass', hash_password('pass'))
 
 
 def test_verify_password_bcrypt_single_hash(app, sqlalchemy_datastore):
@@ -30,7 +30,7 @@ def test_verify_password_bcrypt_single_hash(app, sqlalchemy_datastore):
         'SECURITY_PASSWORD_SINGLE_HASH': True,
     })
     with app.app_context():
-        assert verify_password('pass', encrypt_password('pass'))
+        assert verify_password('pass', hash_password('pass'))
 
 
 def test_verify_password_single_hash_list(app, sqlalchemy_datastore):
@@ -44,7 +44,7 @@ def test_verify_password_single_hash_list(app, sqlalchemy_datastore):
     })
     with app.app_context():
         # double hash
-        assert verify_password('pass', encrypt_password('pass'))
+        assert verify_password('pass', hash_password('pass'))
         assert verify_password('pass', pbkdf2_sha256.hash(get_hmac('pass')))
         # single hash
         assert verify_password('pass', django_pbkdf2_sha256.hash('pass'))
@@ -59,7 +59,7 @@ def test_verify_password_backward_compatibility(app, sqlalchemy_datastore):
     })
     with app.app_context():
         # double hash
-        assert verify_password('pass', encrypt_password('pass'))
+        assert verify_password('pass', hash_password('pass'))
         # single hash
         assert verify_password('pass', plaintext.hash('pass'))
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,7 +10,7 @@ from flask import Response as BaseResponse
 from flask import json
 
 from flask_security import Security
-from flask_security.utils import encrypt_password
+from flask_security.utils import hash_password
 
 _missing = object
 
@@ -60,7 +60,7 @@ def create_users(ds, count=None):
     for u in users[:count]:
         pw = u[2]
         if pw is not None:
-            pw = encrypt_password(pw)
+            pw = hash_password(pw)
         roles = [ds.find_or_create_role(rn) for rn in u[3]]
         ds.commit()
         user = ds.create_user(


### PR DESCRIPTION
Simple add of the token to be available in the email templates.

When using with an application via REST, being able to integrate with the device native app, using something like Branch.io. This will allow a click via email to open either the native app, app store, or web site, to perform the function using the token from the request.

Unit tests included, as well as some other minor fixes to the testing environment.