### PR TITLE
adds relevant user to reset password form for validation purposes

### DIFF
--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -287,6 +287,7 @@ def reset_password(token):
         return redirect(url_for('forgot_password'))
 
     form = _security.reset_password_form()
+    form.user = user
 
     if form.validate_on_submit():
         after_this_request(_commit)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -10,6 +10,8 @@
     :copyright: (c) 2011 by Armin Ronacher.
     :license: BSD, see LICENSE for more details.
 """
+from __future__ import print_function
+
 import os
 import re
 import sys
@@ -111,12 +113,12 @@ def build_and_upload():
 
 
 def fail(message, *args):
-    print >> sys.stderr, 'Error:', message % args
+    print('Error: %s' % message % args, file=sys.stderr)
     sys.exit(1)
 
 
 def info(message, *args):
-    print >> sys.stderr, message % args
+    print(message % args, file=sys.stderr)
 
 
 def get_git_tags():


### PR DESCRIPTION
I need a way to check password complexity, including relevant information about the user (such as their first and last name). Currently ResetPasswordForm has no mechanism for doing this, since `current_user` is `AnonymousUser` at this point.

This simply tacks on `user` from the token so that the `ResetPasswordForm` can fully implement complexity checks against the proposed user-to-change's data as extra dictionary items (example of the sort of checks I'd like to perform here: https://github.com/dwolfhub/zxcvbn-python#usage)