### PR TITLE
in memory cache verify password implementation

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -82,6 +82,17 @@ Core
 ``SECURITY_DEFAULT_HTTP_AUTH_REALM``     Specifies the default authentication
                                          realm when using basic HTTP auth.
                                          Defaults to ``Login Required``
+``USE_VERIFY_PASSWORD_CACHE``            If ``True`` Enables cache for token
+                                         verification, make it quicker further
+                                         calls to authenticated routes using
+                                         token and slow hash algorithms
+                                         (like bcrypt). Defaults to ``None``
+``VERIFY_HASH_CACHE_MAX_SIZE``           Limitation for token validation cache size
+                                         Rules are the ones of TTLCache of
+                                         cachetools package. Defaults to
+                                         ``500``
+``VERIFY_HASH_CACHE_TTL``                Time to live for password check cache entries.
+                                         Defaults to ``300`` (5 minutes)
 ======================================== =======================================
 
 

--- a/flask_security/cache.py
+++ b/flask_security/cache.py
@@ -1,0 +1,26 @@
+from flask import current_app
+from cachetools import TTLCache
+
+
+class VerifyHashCache:
+    """Cache handler to make it quick password check by bypassing
+    already checked passwords against exact same couple of token/password.
+    This cache handler is more efficient on small apps that
+    run on few processes as cache is only shared between threads."""
+
+    def __init__(self):
+        ttl = current_app.config.get("VERIFY_HASH_CACHE_TTL", 60 * 5)
+        max_size = current_app.config.get("VERIFY_HASH_CACHE_MAX_SIZE", 500)
+        self._cache = TTLCache(max_size, ttl)
+
+    def has_verify_hash_cache(self, user):
+        """Check given user id is in cache."""
+        return self._cache.get(user.id)
+
+    def set_cache(self, user):
+        """When a password is checked, then result is put in cache."""
+        self._cache[user.id] = True
+
+    def clear(self):
+        """Clear cache"""
+        self._cache.clear()

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ install_requires = [
     'Flask-BabelEx>=0.9.3',
     'itsdangerous>=0.21',
     'passlib>=1.7',
+    'cachetools>=3.1.0',
 ]
 
 packages = find_packages()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+"""
+    test_cache
+    ~~~~~~~~~~~~
+
+    verify hash cache tests
+"""
+
+from flask_security.cache import VerifyHashCache
+from flask_security.core import _request_loader, local_cache
+
+
+class MockRequest:
+    @property
+    def headers(self):
+        return {"token-header": "mock-token-header"}
+
+    @property
+    def args(self):
+        return {}
+
+    @property
+    def is_json(self):
+        return True
+
+    def get_json(self, silent=None):
+        return {}
+
+
+class MockUser:
+    def __init__(self, id, password):
+        self.id = id
+        self.password = password
+
+
+class MockExtensionSecurity:
+    @property
+    def token_authentication_header(self):
+        return "token-header"
+
+    @property
+    def token_authentication_key(self):
+        return "token-key"
+
+    @property
+    def login_manager(self):
+        class MockLoginManager:
+            def anonymous_user(self):
+                return None
+
+        return MockLoginManager()
+
+    @property
+    def remember_token_serializer(self):
+        class MockLoader:
+            def loads(self, token, max_age):
+                return [1, "token"]
+
+        return MockLoader()
+
+    @property
+    def token_max_age(self):
+        return 1
+
+    @property
+    def datastore(self):
+        class MockDataStore:
+            def find_user(self, id=None):
+                return MockUser(id, "token")
+
+        return MockDataStore()
+
+    @property
+    def hashing_context(self):
+        class MockHashingContext:
+            def verify(self, encoded_data, hashed_data):
+                return encoded_data.decode() == hashed_data
+
+        return MockHashingContext()
+
+
+def test_verify_password_cache_init(app):
+    with app.app_context():
+        vhc = VerifyHashCache()
+        assert len(vhc._cache) == 0
+        assert vhc._cache.ttl == 60 * 5
+        assert vhc._cache.maxsize == 500
+        app.config["VERIFY_HASH_CACHE_TTL"] = 10
+        app.config["VERIFY_HASH_CACHE_MAX_SIZE"] = 10
+        vhc = VerifyHashCache()
+        assert vhc._cache.ttl == 10
+        assert vhc._cache.maxsize == 10
+
+
+def test_verify_password_cache_set_get(app):
+    class MockUser:
+        def __init__(self, id):
+            self.id = id
+
+    user = MockUser(1)
+    with app.app_context():
+        vhc = VerifyHashCache()
+        assert vhc.has_verify_hash_cache(user) is None
+        vhc.set_cache(user)
+        assert len(vhc._cache) == 1
+        assert vhc.has_verify_hash_cache(user)
+        vhc.clear()
+        assert vhc.has_verify_hash_cache(user) is None
+
+
+def test_request_loader_not_using_cache(app):
+    with app.app_context():
+        app.extensions["security"] = MockExtensionSecurity()
+        _request_loader(MockRequest())
+        assert getattr(local_cache, "verify_hash_cache", None) is None
+
+
+def test_request_loader_using_cache(app):
+    with app.app_context():
+        app.config["USE_VERIFY_PASSWORD_CACHE"] = True
+        app.extensions["security"] = MockExtensionSecurity()
+        _request_loader(MockRequest())
+        assert local_cache.verify_hash_cache is not None
+        assert local_cache.verify_hash_cache.has_verify_hash_cache(MockUser(1, "token"))


### PR DESCRIPTION
As bcrypt algorithm computations are expensives and long, I implemented a simple cache system allowing to bypass token validation on each requests when the same validation is already in cache.

The result is a combination of the token and the user passwords. Documentation in the code describes more in detail the implementation. 

It's usage is optionnal when the USE_VERIFY_PASSWORD_CACHE is set.

I would like some maintainer of the repository validate the code before I go further by adding options in documentation and implementing unit tests. I would be pleased to do this if this current commit is accepted.