### PR TITLE
Use new Flask-Login request_loader to set request callback

### DIFF
--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -63,7 +63,7 @@ def _get_unauthorized_view():
 
 
 def _check_token():
-    user = _security.login_manager.request_callback(request)
+    user = _security.login_manager.request_loader(request)
 
     if user and user.is_authenticated:
         app = current_app._get_current_object()


### PR DESCRIPTION
Request loader callback was renamed in Flask-Login 0.5.0 to conform with other user/header loader names. Fixes #856.