### PR TITLE
docs: Fix simple typo, existung -> existing

### DIFF
--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -233,12 +233,12 @@ class LoginForm(Form, NextFormMixin):
 
         if self.user is None:
             self.email.errors.append(get_message('USER_DOES_NOT_EXIST')[0])
-            # Reduce timing variation between existing and non-existung users
+            # Reduce timing variation between existing and non-existing users
             hash_password(self.password.data)
             return False
         if not self.user.password:
             self.password.errors.append(get_message('PASSWORD_NOT_SET')[0])
-            # Reduce timing variation between existing and non-existung users
+            # Reduce timing variation between existing and non-existing users
             hash_password(self.password.data)
             return False
         if not self.user.verify_and_update_password(self.password.data):


### PR DESCRIPTION
There is a small typo in flask_security/forms.py.

Should read `existing` rather than `existung`.

