### PR TITLE
Compatibility with Flask 3.0.0

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -541,10 +541,10 @@ class Security(object):
             app.register_blueprint(create_blueprint(state, __name__))
             app.context_processor(_context_processor)
 
-        @app.before_first_request
-        def _register_i18n():
-            if '_' not in app.jinja_env.globals:
-                app.jinja_env.globals['_'] = state.i18n_domain.gettext
+        # @app.before_first_request
+        # def _register_i18n():
+        if '_' not in app.jinja_env.globals:
+            app.jinja_env.globals['_'] = state.i18n_domain.gettext
 
         state.render_template = self.render_template
         state.send_mail = self.send_mail

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -12,7 +12,7 @@
 from collections import namedtuple
 from functools import wraps
 
-from flask import Response, _request_ctx_stack, abort, current_app, redirect, \
+from flask import Response, abort, current_app, redirect, \
     request, url_for
 from flask_login import current_user, login_required  # pragma: no flakes
 from flask_principal import Identity, Permission, RoleNeed, identity_changed
@@ -67,7 +67,7 @@ def _check_token():
 
     if user and user.is_authenticated:
         app = current_app._get_current_object()
-        _request_ctx_stack.top.user = user
+        g.user = user
         identity_changed.send(app, identity=Identity(user.id))
         return True
 
@@ -83,7 +83,7 @@ def _check_http_auth():
     if user and user.verify_and_update_password(auth.password):
         _security.datastore.commit()
         app = current_app._get_current_object()
-        _request_ctx_stack.top.user = user
+        g.user = user
         identity_changed.send(app, identity=Identity(user.id))
         return True
 

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -12,9 +12,10 @@
 
 import inspect
 
-from flask import Markup, current_app, flash, request
+from flask import current_app, flash, request
 from flask_login import current_user
 from flask_wtf import FlaskForm as BaseForm
+from markupsafe import Markup
 from speaklater import make_lazy_gettext
 from wtforms import BooleanField, Field, HiddenField, PasswordField, \
     StringField, SubmitField, ValidationError, validators


### PR DESCRIPTION
Current version of flask_security isn't compatible with Flask 3.0.0. (deprecated exported attributes are removed, Markup isn't reexported anymore)